### PR TITLE
Fix backend testing error due to attribute rename

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -81,7 +81,7 @@ class OrchestratorInventory(RESTController):
             node_osds = device_osd_map.get(inventory_node['name'])
             for device in inventory_node['devices']:
                 if node_osds:
-                    device['osd_ids'] = sorted(node_osds.get(device['id'], []))
+                    device['osd_ids'] = sorted(node_osds.get(device['path'], []))
                 else:
                     device['osd_ids'] = []
         return inventory_nodes

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -4,8 +4,6 @@ try:
 except ImportError:
     from unittest import mock
 
-from ceph.deployment.inventory import Devices
-
 from orchestrator import InventoryNode, ServiceDescription
 
 from . import ControllerTestCase
@@ -68,16 +66,16 @@ class OrchestratorControllerTest(ControllerTestCase):
             {
                 'name': 'host-0',
                 'devices': [
-                    {'id': 'nvme0n1'},
-                    {'id': 'sdb'},
-                    {'id': 'sdc'},
+                    {'path': 'nvme0n1'},
+                    {'path': 'sdb'},
+                    {'path': 'sdc'},
                 ]
             },
             {
                 'name': 'host-1',
                 'devices': [
-                    {'id': 'sda'},
-                    {'id': 'sdb'},
+                    {'path': 'sda'},
+                    {'path': 'sdb'},
                 ]
             }
         ]


### PR DESCRIPTION
`id` in Device is renamed to `path`.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
