### PR TITLE
mgr/orchestrator: use finalize to set TrivialReadCompletion result

### DIFF
--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -114,9 +114,9 @@ Completions and batching
 ------------------------
 
 All methods that read or modify the state of the system can potentially
-be long running.  To handle that, all such methods return a *completion*
-object (a *ReadCompletion* or a *WriteCompletion*).  Orchestrator modules
-must implement the *wait* method: this takes a list of completions, and
+be long running.  To handle that, all such methods return a *Completion*
+object.  Orchestrator modules
+must implement the *process* method: this takes a list of completions, and
 is responsible for checking if they're finished, and advancing the underlying
 operations as needed.
 
@@ -125,24 +125,21 @@ for completions.  This might involve running the underlying operations
 in threads, or batching the operations up before later executing
 in one go in the background.  If implementing such a batching pattern, the
 module would do no work on any operation until it appeared in a list
-of completions passed into *wait*.
+of completions passed into *process*.
 
-*WriteCompletion* objects have a two-stage execution.  First they become
-*persistent*, meaning that the write has made it to the orchestrator
-itself, and been persisted there (e.g. a manifest file has been updated).
-If ceph-mgr crashed at this point, the operation would still eventually take
-effect.  Second, the completion becomes *effective*, meaning that the operation has really happened (e.g. a service has actually been started).
+Some operations need to show a progress. Those operations need to add
+a *ProgressReference* to the completion. At some point, the progress reference
+becomes *effective*, meaning that the operation has really happened
+(e.g. a service has actually been started).
 
-.. automethod:: Orchestrator.wait
+.. automethod:: Orchestrator.process
 
-.. autoclass:: _Completion
+.. autoclass:: Completion
    :members:
 
-.. autoclass:: ReadCompletion
+.. autoclass:: ProgressReference
    :members:
 
-.. autoclass:: WriteCompletion
-   :members:
 
 Placement
 ---------
@@ -196,7 +193,7 @@ In detail, orchestrators need to explicitly deal with different kinds of errors:
 5. Errors when actually executing commands
 
    The resulting Completion should contain an error string that assists in understanding the
-   problem. In addition, :func:`_Completion.is_errored` is set to ``True``
+   problem. In addition, :func:`Completion.is_errored` is set to ``True``
 
 6. Invalid configuration in the orchestrator modules
 
@@ -205,7 +202,7 @@ In detail, orchestrators need to explicitly deal with different kinds of errors:
 
 All other errors are unexpected orchestrator issues and thus should raise an exception that are then
 logged into the mgr log file. If there is a completion object at that point,
-:func:`_Completion.result` may contain an error message.
+:func:`Completion.result` may contain an error message.
 
 
 Excluded functionality

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -2,6 +2,7 @@ import errno
 import json
 import logging
 from tempfile import NamedTemporaryFile
+from time import sleep
 
 from teuthology.exceptions import CommandFailedError
 
@@ -180,6 +181,7 @@ class TestOrchestratorCli(MgrTestCase):
         evs = json.loads(self._progress_cmd('json'))['completed']
         self.assertEqual(len(evs), 0)
         self._orch_cmd("mgr", "update", "4")
+        sleep(6)  # There is a sleep(5) in the test_orchestrator.module.serve()
         evs = json.loads(self._progress_cmd('json'))['completed']
         self.assertEqual(len(evs), 1)
         self.assertIn('update_mgrs', evs[0]['message'])

--- a/src/pybind/mgr/ansible/ansible_runner_svc.py
+++ b/src/pybind/mgr/ansible/ansible_runner_svc.py
@@ -6,8 +6,13 @@ import json
 import re
 from functools import wraps
 import collections
+import logging
+from typing import Optional
 
 import requests
+from orchestrator import OrchestratorError
+
+logger = logging.getLogger(__name__)
 
 # Ansible Runner service API endpoints
 API_URL = "api"
@@ -17,7 +22,7 @@ EVENT_DATA_URL = "api/v1/jobs/%s/events/%s"
 URL_MANAGE_GROUP = "api/v1/groups/{group_name}"
 URL_ADD_RM_HOSTS = "api/v1/hosts/{host_name}/groups/{inventory_group}"
 
-class AnsibleRunnerServiceError(Exception):
+class AnsibleRunnerServiceError(OrchestratorError):
     """Generic Ansible Runner Service Exception"""
     pass
 
@@ -46,9 +51,12 @@ class PlayBookExecution(object):
     """Object to provide all the results of a Playbook execution
     """
 
-    def __init__(self, rest_client, playbook, logger, result_pattern="",
-                 the_params=None,
-                 querystr_dict=None):
+    def __init__(self, rest_client,  # type: Client
+                 playbook,  # type: str
+                 result_pattern="",  # type: str
+                 the_params=None,  # type: Optional[dict]
+                 querystr_dict=None  # type: Optional[dict]
+                 ):
 
         self.rest_client = rest_client
 
@@ -67,9 +75,6 @@ class PlayBookExecution(object):
         # Query string used in the "launch" request
         self.querystr_dict = querystr_dict
 
-        # Logger
-        self.log = logger
-
     def launch(self):
         """ Launch the playbook execution
         """
@@ -82,7 +87,7 @@ class PlayBookExecution(object):
                                                   self.params,
                                                   self.querystr_dict)
         except AnsibleRunnerServiceError:
-            self.log.exception("Error launching playbook <%s>", self.playbook)
+            logger.exception("Error launching playbook <%s>", self.playbook)
             raise
 
         # Here we have a server response, but an error trying
@@ -91,7 +96,7 @@ class PlayBookExecution(object):
         # to the orchestrator (via completion object)
         if response.ok:
             self.play_uuid = json.loads(response.text)["data"]["play_uuid"]
-            self.log.info("Playbook execution launched succesfuly")
+            logger.info("Playbook execution launched succesfuly")
         else:
             raise AnsibleRunnerServiceError(response.reason)
 
@@ -117,7 +122,7 @@ class PlayBookExecution(object):
             try:
                 response = self.rest_client.http_get(endpoint)
             except AnsibleRunnerServiceError:
-                self.log.exception("Error getting playbook <%s> status",
+                logger.exception("Error getting playbook <%s> status",
                                    self.playbook)
 
             if response:
@@ -131,7 +136,7 @@ class PlayBookExecution(object):
             else:
                 status_value = ExecutionStatusCode.ERROR
 
-        self.log.info("Requested playbook execution status is: %s", status_value)
+        logger.info("Requested playbook execution status is: %s", status_value)
         return status_value
 
     def get_result(self, event_filter):
@@ -148,7 +153,7 @@ class PlayBookExecution(object):
         try:
             response = self.rest_client.http_get(PLAYBOOK_EVENTS % self.play_uuid)
         except AnsibleRunnerServiceError:
-            self.log.exception("Error getting playbook <%s> result", self.playbook)
+            logger.exception("Error getting playbook <%s> result", self.playbook)
 
         if not response:
             result_events = {}
@@ -170,7 +175,7 @@ class PlayBookExecution(object):
                 result_events = {event:data for event, data in result_events.items()
                                  if re.match(type_of_events, data['event'])}
 
-        self.log.info("Requested playbook result is: %s", json.dumps(result_events))
+        logger.info("Requested playbook result is: %s", json.dumps(result_events))
         return result_events
 
 class Client(object):
@@ -178,8 +183,13 @@ class Client(object):
     and execute easily playbooks
     """
 
-    def __init__(self, server_url, verify_server, ca_bundle, client_cert,
-                 client_key, logger):
+    def __init__(self,
+                 server_url,  # type: str
+                 verify_server,  # type: bool
+                 ca_bundle,  # type: str
+                 client_cert, # type: str
+                 client_key  # type: str
+                 ):
         """Provide an https client to make easy interact with the Ansible
         Runner Service"
 
@@ -194,17 +204,15 @@ class Client(object):
                             file
         :param client_key: Path to Ansible Runner Service client certificate key
                            file
-        :param logger: Log file
         """
         self.server_url = server_url
-        self.log = logger
         self.client_cert = (client_cert, client_key)
 
         # used to provide the "verify" parameter in requests
         # a boolean that sometimes contains a string :-(
         self.verify_server = verify_server
         if ca_bundle: # This intentionallly overwrites
-            self.verify_server = ca_bundle
+            self.verify_server = ca_bundle  # type: ignore
 
         self.server_url = "https://{0}".format(self.server_url)
 
@@ -238,11 +246,11 @@ class Client(object):
                                 headers={})
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http GET %s <--> (%s - %s)\n%s",
+            logger.error("http GET %s <--> (%s - %s)\n%s",
                            the_url, response.status_code, response.reason,
                            response.text)
         else:
-            self.log.info("http GET %s <--> (%s - %s)",
+            logger.info("http GET %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -267,11 +275,11 @@ class Client(object):
                                  params=params_dict)
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http POST %s [%s] <--> (%s - %s:%s)\n",
+            logger.error("http POST %s [%s] <--> (%s - %s:%s)\n",
                            the_url, payload, response.status_code,
                            response.reason, response.text)
         else:
-            self.log.info("http POST %s <--> (%s - %s)",
+            logger.info("http POST %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -292,11 +300,11 @@ class Client(object):
                                    headers={})
 
         if response.status_code != requests.codes.ok:
-            self.log.error("http DELETE %s <--> (%s - %s)\n%s",
+            logger.error("http DELETE %s <--> (%s - %s)\n%s",
                            the_url, response.status_code, response.reason,
                            response.text)
         else:
-            self.log.info("http DELETE %s <--> (%s - %s)",
+            logger.info("http DELETE %s <--> (%s - %s)",
                           the_url, response.status_code, response.text)
 
         return response
@@ -400,6 +408,7 @@ class InventoryGroup(collections.MutableSet):
     """ Manages an Ansible Inventory Group
     """
     def __init__(self, group_name, ars_client):
+        # type: (str, Client) -> None
         """Init the group_name attribute and
            Create the inventory group if it does not exist
 

--- a/src/pybind/mgr/ansible/ansible_runner_svc.py
+++ b/src/pybind/mgr/ansible/ansible_runner_svc.py
@@ -7,7 +7,10 @@ import re
 from functools import wraps
 import collections
 import logging
-from typing import Optional
+try:
+    from typing import Optional
+except ImportError:
+    pass # just for type checking
 
 import requests
 from orchestrator import OrchestratorError

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -10,8 +10,12 @@ import json
 import os
 import errno
 import tempfile
-from typing import List, Any, Optional, Callable, Tuple, TypeVar
-T = TypeVar('T')
+
+try:
+    from typing import List, Optional, Callable
+except ImportError:
+    pass # just for type checking
+
 
 import requests
 
@@ -66,7 +70,7 @@ URL_GET_HOSTS = "api/v1/hosts"
 
 
 def deferred(f):
-    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
+    # type: (Callable) -> Callable[..., orchestrator.Completion]
     """
     Decorator to make RookOrchestrator methods return
     a completion object that executes themselves.

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -475,7 +475,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         return (available, msg)
 
-    def wait(self, completions):
+    def process(self, completions):
         """Given a list of Completion instances, progress any which are
            incomplete.
 
@@ -487,13 +487,6 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Access completion.status property do the trick
         for operation in completions:
             self.log.info("<%s> status:%s", operation, operation.status)
-
-        completions = filter(lambda x: not x.is_complete, completions)
-
-        ops_pending = len(completions)
-        self.log.info("Operations pending: %s", ops_pending)
-
-        return ops_pending == 0
 
     def serve(self):
         """ Mandatory for standby modules

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -5,11 +5,14 @@ The external Orchestrator is the Ansible runner service (RESTful https service)
 """
 
 # pylint: disable=abstract-method, no-member, bad-continuation
-
+import functools
 import json
 import os
 import errno
 import tempfile
+from typing import List, Any, Optional, Callable, Tuple, TypeVar
+T = TypeVar('T')
+
 import requests
 
 from mgr_module import MgrModule, Option, CLIWriteCommand
@@ -21,7 +24,9 @@ from .ansible_runner_svc import Client, PlayBookExecution, ExecutionStatusCode,\
                                 URL_MANAGE_GROUP, URL_ADD_RM_HOSTS
 
 from .output_wizards import ProcessInventory, ProcessPlaybookResult, \
-                            ProcessHostsList
+                            ProcessHostsList, OutputWizard
+
+
 
 # Time to clean the completions list
 WAIT_PERIOD = 10
@@ -59,366 +64,158 @@ URL_GET_HOST_GROUPS = "api/v1/hosts/{host_name}"
 URL_GET_HOSTS = "api/v1/hosts"
 
 
-class AnsibleReadOperation(orchestrator.ReadCompletion):
-    """ A read operation means to obtain information from the cluster.
+
+def deferred(f):
+    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
     """
-    def __init__(self, client, logger):
-        """
-        :param client        : Ansible Runner Service Client
-        :param logger        : The object used to log messages
-        """
-        super(AnsibleReadOperation, self).__init__()
-
-        # Private attributes
-        self._is_complete = False
-        self._is_errored = False
-        self._result = []
-        self._status = ExecutionStatusCode.NOT_LAUNCHED
-
-        # Object used to process operation result in different ways
-        self.output_wizard = None
-
-        # Error description in operation
-        self.error = ""
-
-        # Ansible Runner Service client
-        self.ar_client = client
-
-        # Logger
-        self.log = logger
-
-    def __str__(self):
-        return "Playbook {playbook_name}".format(playbook_name=self.playbook)
-
-    @property
-    def has_result(self):
-        return self._is_complete
-
-    @property
-    def is_errored(self):
-        return self._is_errored
-
-    @property
-    def result(self):
-        return self._result
-
-    @property
-    def status(self):
-        """Retrieve the current status of the operation and update state
-        attributes
-        """
-        raise NotImplementedError()
-
-class ARSOperation(AnsibleReadOperation):
-    """Execute an Ansible Runner Service Operation
+    Decorator to make RookOrchestrator methods return
+    a completion object that executes themselves.
     """
 
-    def __init__(self, client, logger, url, get_operation=True, payload=None):
-        """
-        :param client        : Ansible Runner Service Client
-        :param logger        : The object used to log messages
-        :param url           : The Ansible Runner Service URL that provides
-                               the operation
-        :param get_operation : True if operation is provided using an http GET
-        :param payload       : http request payload
-        """
-        super(ARSOperation, self).__init__(client, logger)
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return orchestrator.Completion(on_complete=lambda _: f(*args, **kwargs))
 
-        self.url = url
-        self.get_operation = get_operation
-        self.payload = payload
-
-    def __str__(self):
-        return "Ansible Runner Service: {operation} {url}".format(
-                    operation="GET" if self.get_operation else "POST",
-                    url=self.url)
-
-    @property
-    def status(self):
-        """ Execute the Ansible Runner Service operation and update the status
-        and result of the underlying Completion object.
-        """
-
-        # Execute the right kind of http request
-        if self.get_operation:
-            response = self.ar_client.http_get(self.url)
-        else:
-            response = self.ar_client.http_post(self.url, self.payload)
-
-        # If no connection errors, the operation is complete
-        self._is_complete = True
-
-        # Depending of the response, status and result is updated
-        if not response:
-            self._is_errored = True
-            self._status = ExecutionStatusCode.ERROR
-            self._result = "Ansible Runner Service not Available"
-        else:
-            self._is_errored = (response.status_code != requests.codes.ok)
-
-            if not self._is_errored:
-                self._status = ExecutionStatusCode.SUCCESS
-                if self.output_wizard:
-                    self._result = self.output_wizard.process(self.url,
-                                                              response.text)
-                else:
-                    self._result = response.text
-            else:
-                self._status = ExecutionStatusCode.ERROR
-                self._result = response.reason
-
-        return self._status
+    return wrapper
 
 
-class PlaybookOperation(AnsibleReadOperation):
-    """Execute a playbook using the Ansible Runner Service
+def clean_inventory(ar_client, clean_hosts_on_success):
+    # type: (Client, dict) -> None
+    """ Remove hosts from inventory groups
     """
 
-    def __init__(self, client, playbook, logger, result_pattern,
-                 params,
-                 querystr_dict={}):
-        """
-        :param client        : Ansible Runner Service Client
-        :param playbook      : The playbook to execute
-        :param logger        : The object used to log messages
-        :param result_pattern: The "pattern" to discover what execution events
-                               have the information deemed as result
-        :param params        : http request payload for the playbook execution
-        :param querystr_dict : http request querystring for the playbook
-                               execution (DO NOT MODIFY HERE)
+    for group, hosts in clean_hosts_on_success.items():
+        InventoryGroup(group, ar_client).clean(hosts)
 
-        """
-        super(PlaybookOperation, self).__init__(client, logger)
 
-       # Private attributes
-        self.playbook = playbook
+def playbook_operation(client,  # type: Client
+                       playbook,  # type: str
+                       result_pattern,  # type: str
+                       params,  # type: dict
+                       event_filter_list=None,  # type: Optional[List[str]]
+                       querystr_dict=None,  # type: Optional[dict]
+                       output_wizard=None,  # type: Optional[OutputWizard]
+                       clean_hosts_on_success=None  # type: Optional[dict]
+                       ):
+    # type: (...) -> orchestrator.Completion
+    """
+    :param client        : Ansible Runner Service Client
+    :param playbook      : The playbook to execute
+    :param result_pattern: The "pattern" to discover what execution events
+                           have the information deemed as result
+    :param params        : http request payload for the playbook execution
+    :param querystr_dict : http request querystring for the playbook
+                           execution (DO NOT MODIFY HERE)
+    :param event_filter_list: An aditional filter of result events based in the event
+    :param clean_hosts_on_success: A dict with groups and hosts to remove from inventory if operation is
+        succesful. Ex: {"group1": ["host1"], "group2": ["host3", "host4"]}
+    """
 
-        # An aditional filter of result events based in the event
-        self.event_filter_list = [""]
+    querystr_dict = querystr_dict or {}
+    event_filter_list = event_filter_list or [""]
+    clean_hosts_on_success = clean_hosts_on_success or {}
 
-        # A dict with groups and hosts to remove from inventory if operation is
-        # succesful. Ex: {"group1": ["host1"], "group2": ["host3", "host4"]}
-        self.clean_hosts_on_success = {}
-
-        # Playbook execution object
-        self.pb_execution = PlayBookExecution(client,
-                                              playbook,
-                                              logger,
-                                              result_pattern,
-                                              params,
-                                              querystr_dict)
-
-    def __str__(self):
-        return "Playbook {playbook_name}".format(playbook_name=self.playbook)
-
-    @property
-    def status(self):
+    def status(_):
         """Check the status of the playbook execution and update the status
         and result of the underlying Completion object.
         """
 
-        if self._status in [ExecutionStatusCode.ON_GOING,
-                            ExecutionStatusCode.NOT_LAUNCHED]:
-            self._status = self.pb_execution.get_status()
+        status = pb_execution.get_status()
 
-        self._is_complete = (self._status == ExecutionStatusCode.SUCCESS) or \
-                            (self._status == ExecutionStatusCode.ERROR)
+        if status in (ExecutionStatusCode.SUCCESS, ExecutionStatusCode.ERROR):
+            if status == ExecutionStatusCode.ERROR:
+                raw_result = pb_execution.get_result(["runner_on_failed",
+                                                      "runner_on_unreachable",
+                                                      "runner_on_no_hosts",
+                                                      "runner_on_async_failed",
+                                                      "runner_item_on_failed"])
+            else:
+                raw_result = pb_execution.get_result(event_filter_list)
 
-        self._is_errored = (self._status == ExecutionStatusCode.ERROR)
-
-        if self._is_complete:
-            self.update_result()
+            if output_wizard:
+                processed_result = output_wizard.process(pb_execution.play_uuid,
+                                                         raw_result)
+            else:
+                processed_result = raw_result
 
             # Clean hosts if operation is succesful
-            if self._status == ExecutionStatusCode.SUCCESS:
-                self.clean_inventory()
+            if status == ExecutionStatusCode.SUCCESS:
+                clean_inventory(client, clean_hosts_on_success)
 
-        return self._status
-
-    def execute_playbook(self):
-        """Launch the execution of the playbook with the parameters configured
-        """
-        try:
-            self.pb_execution.launch()
-        except AnsibleRunnerServiceError:
-            self._status = ExecutionStatusCode.ERROR
-            raise
-
-    def update_result(self):
-        """Output of the read operation
-
-        The result of the playbook execution can be customized through the
-        function provided as 'process_output' attribute
-
-        :return string: Result of the operation formatted if it is possible
-        """
-
-        processed_result = []
-
-        if self._is_errored:
-            raw_result = self.pb_execution.get_result(["runner_on_failed",
-                                                       "runner_on_unreachable",
-                                                       "runner_on_no_hosts",
-                                                       "runner_on_async_failed",
-                                                       "runner_item_on_failed"])
-        elif self._is_complete:
-            raw_result = self.pb_execution.get_result(self.event_filter_list)
-
-        if self.output_wizard:
-            processed_result = self.output_wizard.process(self.pb_execution.play_uuid,
-                                                          raw_result)
+            return processed_result
         else:
-            processed_result = raw_result
+            return orchestrator.Completion(on_complete=status)
 
-        self._result = processed_result
+    pb_execution = PlayBookExecution(client, playbook, result_pattern, params, querystr_dict)
 
-    def clean_inventory(self):
-        """ Remove hosts from inventory groups
-        """
-
-        for group, hosts in self.clean_hosts_on_success.items():
-            InventoryGroup(group, self.ar_client).clean(hosts)
-            del self.clean_hosts_on_success[group]
+    return orchestrator.Completion(on_complete=lambda _: pb_execution.launch()).then(status)
 
 
+def ars_http_operation(url, http_operation, payload="", params_dict=None):
+    def inner(ar_client):
+        # type: (Client) -> str
+        if http_operation == "post":
+            response = ar_client.http_post(url,
+                                           payload,
+                                           params_dict)
+        elif http_operation == "delete":
+            response = ar_client.http_delete(url)
+        elif http_operation == "get":
+            response = ar_client.http_get(url)
+        else:
+            assert False, http_operation
 
-class AnsibleChangeOperation(orchestrator.WriteCompletion):
-    """Operations that changes the "cluster" state
+        # Any problem executing the secuence of operations will
+        # produce an errored completion object.
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            raise AnsibleRunnerServiceError(str(e))
 
-    Modifications/Changes (writes) are a two-phase thing, firstly execute
-    the playbook that is going to change elements in the Ceph Cluster.
-    When the playbook finishes execution (independently of the result),
-    the modification/change operation has finished.
+        return response.text
+    return inner
+
+
+@deferred
+def ars_change(client, operations, output_wizard=None):
+    # type: (Client, List[Callable[[Client], str]], Optional[OutputWizard]) -> str
     """
-    def __init__(self):
-        super(AnsibleChangeOperation, self).__init__()
-
-        self._status = ExecutionStatusCode.NOT_LAUNCHED
-        self._result = None
-
-        # Object used to process operation result in different ways
-        self.output_wizard = None
-
-    @property
-    def status(self):
-        """Return the status code of the operation
-        """
-        raise NotImplementedError()
-
-    @property
-    def has_result(self):
-        """
-        Has the operation updated the orchestrator's configuration
-        persistently?  Typically this would indicate that an update
-        had been written to a manifest, but that the update
-        had not necessarily been pushed out to the cluster.
-
-        :return Boolean: True if the execution of the Ansible Playbook or the
-                         operation over the Ansible Runner Service has finished
-        """
-
-        return self._status in [ExecutionStatusCode.SUCCESS,
-                                ExecutionStatusCode.ERROR]
-
-    @property
-    def is_effective(self):
-        """Has the operation taken effect on the cluster?
-        For example, if we were adding a service, has it come up and appeared
-        in Ceph's cluster maps?
-
-        In the case of Ansible, this will be True if the playbooks has been
-        executed succesfully.
-
-        :return Boolean: if the playbook/ARS operation has been executed
-                         succesfully
-        """
-
-        return self._status == ExecutionStatusCode.SUCCESS
-
-    @property
-    def is_errored(self):
-        return self._status == ExecutionStatusCode.ERROR
-
-    @property
-    def result(self):
-        return self._result
-
-class HttpOperation(object):
-    """A class to ease the management of http operations
-    """
-
-    def __init__(self, url, http_operation, payload="", query_string="{}"):
-        self.url = url
-        self.http_operation = http_operation
-        self.payload = payload
-        self.query_string = query_string
-        self.response = None
-
-class ARSChangeOperation(AnsibleChangeOperation):
-    """Execute one or more Ansible Runner Service Operations that implies
+    Execute one or more Ansible Runner Service Operations that implies
     a change in the cluster
+
+    :param client         : Ansible Runner Service Client
+    :param operations     : A list of http_operation objects
+
+    Execute the Ansible Runner Service operations and update the status
+    and result of the underlying Completion object.
     """
-    def __init__(self, client, logger, operations):
-        """
-        :param client         : Ansible Runner Service Client
-        :param logger         : The object used to log messages
-        :param operations     : A list of http_operation objects
-        :param payload        : dict with http request payload
-        """
-        super(ARSChangeOperation, self).__init__()
 
-        assert operations, "At least one operation is needed"
-        self.ar_client = client
-        self.log = logger
-        self.operations = operations
-
-    def __str__(self):
-        # Use the last operation as the main
-        return "Ansible Runner Service: {operation} {url}".format(
-                                operation=self.operations[-1].http_operation,
-                                url=self.operations[-1].url)
-
-    @property
-    def status(self):
-        """Execute the Ansible Runner Service operations and update the status
-        and result of the underlying Completion object.
-        """
-
-        for my_request in self.operations:
-            # Execute the right kind of http request
-            try:
-                if my_request.http_operation == "post":
-                    response = self.ar_client.http_post(my_request.url,
-                                                        my_request.payload,
-                                                        my_request.query_string)
-                elif my_request.http_operation == "delete":
-                    response = self.ar_client.http_delete(my_request.url)
-                elif my_request.http_operation == "get":
-                    response = self.ar_client.http_get(my_request.url)
-
-                # Any problem executing the secuence of operations will
-                # produce an errored completion object.
-                if response.status_code != requests.codes.ok:
-                    self._status = ExecutionStatusCode.ERROR
-                    self._result = response.text
-                    return self._status
-
-            # Any kind of error communicating with ARS or preventing
-            # to have a right http response
-            except AnsibleRunnerServiceError as ex:
-                self._status = ExecutionStatusCode.ERROR
-                self._result = str(ex)
-                return self._status
-
+    out = None
+    for my_request in operations:
+        # Execute the right kind of http request
+        out = my_request(client)
         # If this point is reached, all the operations has been succesfuly
         # executed, and the final result is updated
-        self._status = ExecutionStatusCode.SUCCESS
-        if self.output_wizard:
-            self._result = self.output_wizard.process("", response.text)
-        else:
-            self._result = response.text
+    assert out is not None
+    if output_wizard:
+        return output_wizard.process("", out)
+    else:
+        return out
 
-        return self._status
+
+def ars_read(client, url, get_operation=True, payload=None, output_wizard=None):
+    # type: (Client, str, bool, Optional[str], Optional[OutputWizard]) -> orchestrator.Completion[str]
+    """
+    Execute the Ansible Runner Service operation
+
+    :param client        : Ansible Runner Service Client
+    :param url           : The Ansible Runner Service URL that provides
+                           the operation
+    :param get_operation : True if operation is provided using an http GET
+    :param payload       : http request payload
+    """
+    return ars_change(client, [ars_http_operation(url, 'get' if get_operation else 'post', payload)], output_wizard)
+
 
 class Module(MgrModule, orchestrator.Orchestrator):
     """An Orchestrator that uses <Ansible Runner Service> to perform operations
@@ -440,7 +237,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         self.all_completions = []
 
-        self.ar_client = None
+        self.ar_client = None  # type: Client
 
         # TLS certificate and key file names used to connect with the external
         # Ansible Runner Service
@@ -449,6 +246,9 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         # used to provide more verbose explanation of errors in status method
         self.status_message = ""
+
+        self.all_progress_references = list()  # type: List[orchestrator.ProgressReference]
+
 
     def available(self):
         """ Check if Ansible Runner service is working
@@ -486,7 +286,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Check progress and update status in each operation
         # Access completion.status property do the trick
         for operation in completions:
-            self.log.info("<%s> status:%s", operation, operation.status)
+            self.log.info("<%s> is_finished:%s", operation, operation.is_finished)
 
     def serve(self):
         """ Mandatory for standby modules
@@ -503,8 +303,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
                 verify_server=self.get_module_option('verify_server', True),
                 ca_bundle=self.get_module_option('ca_bundle', ''),
                 client_cert=self.client_cert_fname,
-                client_key=self.client_key_fname,
-                logger=self.log)
+                client_key=self.client_key_fname)
 
         except AnsibleRunnerServiceError:
             self.log.exception("Ansible Runner Service not available. "
@@ -530,54 +329,41 @@ class Module(MgrModule, orchestrator.Orchestrator):
         """
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=GET_STORAGE_DEVICES_CATALOG_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="list storage inventory",
-                                               params={})
+        op = playbook_operation(client=self.ar_client,
+                                playbook=GET_STORAGE_DEVICES_CATALOG_PLAYBOOK,
+                                result_pattern="list storage inventory",
+                                params={},
+                                output_wizard=ProcessInventory(self.ar_client),
+                                event_filter_list=["runner_on_ok"])
 
+        self._launch_operation(op)
 
-        # Assign the process_output function
-        playbook_operation.output_wizard = ProcessInventory(self.ar_client,
-                                                            self.log)
-        playbook_operation.event_filter_list = ["runner_on_ok"]
+        return op
 
-        # Execute the playbook to obtain data
-        self._launch_operation(playbook_operation)
-
-        return playbook_operation
-
-    def create_osds(self, drive_group, all_hosts):
+    def create_osds(self, drive_group):
         """Create one or more OSDs within a single Drive Group.
         If no host provided the operation affects all the host in the OSDS role
 
 
         :param drive_group: (ceph.deployment.drive_group.DriveGroupSpec),
                             Drive group with the specification of drives to use
-        :param all_hosts  : (List[str]),
-                            List of hosts where the OSD's must be created
         """
 
         # Transform drive group specification to Ansible playbook parameters
         host, osd_spec = dg_2_ansible(drive_group)
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=ADD_OSD_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=osd_spec,
-                                               querystr_dict={"limit": host})
+        op = playbook_operation(client=self.ar_client,
+                                playbook=ADD_OSD_PLAYBOOK,
+                                result_pattern="",
+                                params=osd_spec,
+                                querystr_dict={"limit": host},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                  self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
+        self._launch_operation(op)
 
-        # Execute the playbook
-        self._launch_operation(playbook_operation)
-
-        return playbook_operation
+        return op
 
     def remove_osds(self, osd_ids, destroy=False):
         """Remove osd's.
@@ -591,32 +377,24 @@ class Module(MgrModule, orchestrator.Orchestrator):
                      'ireallymeanit':'yes'}
 
         # Create a new read completion object for execute the playbook
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=REMOVE_OSD_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars)
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
-
+        op = playbook_operation(client=self.ar_client,
+                                playbook=REMOVE_OSD_PLAYBOOK,
+                                result_pattern="",
+                                params=extravars,
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
         # Execute the playbook
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def get_hosts(self):
         """Provides a list Inventory nodes
         """
 
-        host_ls_op = ARSOperation(self.ar_client, self.log, URL_GET_HOSTS)
-
-        host_ls_op.output_wizard = ProcessHostsList(self.ar_client,
-                                                    self.log)
-
+        host_ls_op = ars_read(self.ar_client, url=URL_GET_HOSTS,
+                              output_wizard=ProcessHostsList(self.ar_client))
         return host_ls_op
 
     def add_host(self, host):
@@ -625,7 +403,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         group
 
         :param host: hostname
-        :returns : orchestrator.WriteCompletion
+        :returns : orchestrator.Completion
         """
 
         url_group = URL_MANAGE_GROUP.format(group_name=ORCHESTRATOR_GROUP)
@@ -640,16 +418,16 @@ class Module(MgrModule, orchestrator.Orchestrator):
             add_url = URL_ADD_RM_HOSTS.format(host_name=host,
                                               inventory_group=ORCHESTRATOR_GROUP)
 
-            operations = [HttpOperation(add_url, "post", "", None)]
+            operations = [ars_http_operation(add_url, "post", "", None)]
 
         except AnsibleRunnerServiceError as ex:
             # Problems with the external orchestrator.
             # Prepare the operation to return the error in a Completion object.
             self.log.exception("Error checking <orchestrator> group: %s",
                                str(ex))
-            operations = [HttpOperation(url_group, "post", "", None)]
+            operations = [ars_http_operation(url_group, "post", "", None)]
 
-        return ARSChangeOperation(self.ar_client, self.log, operations)
+        return ars_change(self.ar_client, operations)
 
     def remove_host(self, host):
         """
@@ -657,10 +435,9 @@ class Module(MgrModule, orchestrator.Orchestrator):
         inventory.
 
         :param host: hostname
-        :returns : orchestrator.WriteCompletion
+        :returns : orchestrator.Completion
         """
 
-        operations = []
         host_groups = []
 
         try:
@@ -673,25 +450,26 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         except AnsibleRunnerServiceError:
             self.log.exception("Error retrieving host groups")
+            raise
 
         if not host_groups:
             # Error retrieving the groups, prepare the completion object to
             # execute the problematic operation just to provide the error
             # to the caller
-            operations = [HttpOperation(groups_url, "get")]
+            operations = [ars_http_operation(groups_url, "get")]
         else:
             # Build the operations list
             operations = list(map(lambda x:
-                                  HttpOperation(URL_ADD_RM_HOSTS.format(
-                                                    host_name=host,
-                                                    inventory_group=x),
-                                                "delete"),
+                                  ars_http_operation(URL_ADD_RM_HOSTS.format(
+                                      host_name=host,
+                                      inventory_group=x),
+                                      "delete"),
                                   host_groups))
 
-        return ARSChangeOperation(self.ar_client, self.log, operations)
+        return ars_change(self.ar_client, operations)
 
     def add_rgw(self, spec):
-        # type: (orchestrator.RGWSpec) -> PlaybookOperation
+        # type: (orchestrator.RGWSpec) -> orchestrator.Completion
         """ Add a RGW service in the cluster
 
         : spec        : an Orchestrator.RGWSpec object
@@ -743,31 +521,26 @@ class Module(MgrModule, orchestrator.Orchestrator):
         resource_group = "rgw_zone_{}".format(spec.name)
         InventoryGroup(resource_group, self.ar_client).update(hosts)
 
-
         # Execute the playbook to create the service
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=SITE_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars,
-                                               querystr_dict={"limit": limited})
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
+        op = playbook_operation(client=self.ar_client,
+                                playbook=SITE_PLAYBOOK,
+                                result_pattern="",
+                                params=extravars,
+                                querystr_dict={"limit": limited},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"])
 
         # Execute the playbook
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def remove_rgw(self, zone):
         """ Remove a RGW service providing <zone>
 
-        :zone : <zone name> of the RGW
+        :param zone: <zone name> of the RGW
                             ...
-        : returns    : Completion object
+        :returns    : Completion object
         """
 
 
@@ -784,30 +557,25 @@ class Module(MgrModule, orchestrator.Orchestrator):
         # Avoid manual confirmation
         extravars = {"ireallymeanit": "yes"}
 
-        # Execute the playbook to remove the service
-        playbook_operation = PlaybookOperation(client=self.ar_client,
-                                               playbook=PURGE_PLAYBOOK,
-                                               logger=self.log,
-                                               result_pattern="",
-                                               params=extravars,
-                                               querystr_dict={"limit": limited})
-
-        # Filter to get the result
-        playbook_operation.output_wizard = ProcessPlaybookResult(self.ar_client,
-                                                                 self.log)
-        playbook_operation.event_filter_list = ["playbook_on_stats"]
-
         # Cleaning of inventory after a sucessful operation
         clean_inventory = {}
         clean_inventory[resource_group] = hosts_list
         clean_inventory[group] = hosts_list
-        playbook_operation.clean_hosts_on_success = clean_inventory
+
+        # Execute the playbook to remove the service
+        op = playbook_operation(client=self.ar_client,
+                                               playbook=PURGE_PLAYBOOK,
+                                               result_pattern="",
+                                               params=extravars,
+                                               querystr_dict={"limit": limited},
+                                output_wizard=ProcessPlaybookResult(self.ar_client),
+                                event_filter_list=["playbook_on_stats"],
+                                clean_hosts_on_success=clean_inventory)
 
         # Execute the playbook
-        self.log.info("Removing service rgw for resource %s", zone)
-        self._launch_operation(playbook_operation)
+        self._launch_operation(op)
 
-        return playbook_operation
+        return op
 
     def _launch_operation(self, ansible_operation):
         """Launch the operation and add the operation to the completion objects
@@ -815,9 +583,6 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         :ansible_operation: A read/write ansible operation (completion object)
         """
-
-        # Execute the playbook
-        ansible_operation.execute_playbook()
 
         # Add the operation to the list of things ongoing
         self.all_completions.append(ansible_operation)
@@ -837,7 +602,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
         if the_crt is None or the_key is None:
             # If not possible... try to get generic certificates and key content
             # ex: mgr/ansible/[crt/key]
-            self.log.warning("Specific tls files for this manager not "\
+            self.log.warning("Specific tls files for this manager not "
                              "configured, trying to use generic files")
             the_crt = self.get_store("crt")
             the_key = self.get_store("key")

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -91,7 +91,7 @@ class AnsibleReadOperation(orchestrator.ReadCompletion):
         return "Playbook {playbook_name}".format(playbook_name=self.playbook)
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._is_complete
 
     @property
@@ -306,7 +306,7 @@ class AnsibleChangeOperation(orchestrator.WriteCompletion):
         raise NotImplementedError()
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         """
         Has the operation updated the orchestrator's configuration
         persistently?  Typically this would indicate that an update

--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -287,10 +287,8 @@ class Module(MgrModule, orchestrator.Orchestrator):
         :Returns          : True if everything is done.
         """
 
-        # Check progress and update status in each operation
-        # Access completion.status property do the trick
-        for operation in completions:
-            self.log.info("<%s> is_finished:%s", operation, operation.is_finished)
+        if completions:
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
     def serve(self):
         """ Mandatory for standby modules

--- a/src/pybind/mgr/ansible/output_wizards.py
+++ b/src/pybind/mgr/ansible/output_wizards.py
@@ -6,23 +6,24 @@ completion objects
 """
 
 import json
+import logging
 
 from ceph.deployment import inventory
 from orchestrator import InventoryNode
 
 from .ansible_runner_svc import EVENT_DATA_URL
 
+logger = logging.getLogger(__name__)
+
 class OutputWizard(object):
     """Base class for help to process output in completion objects
     """
-    def __init__(self, ar_client, logger):
+    def __init__(self, ar_client):
         """Make easy to work in output wizards using this attributes:
 
         :param ars_client: Ansible Runner Service client
-        :param logger: log object
         """
         self.ar_client = ar_client
-        self.log = logger
 
     def process(self, operation_id, raw_result):
         """Make the magic here
@@ -139,12 +140,12 @@ class ProcessHostsList(OutputWizard):
                 inventory_nodes.append(InventoryNode(host, inventory.Devices([])))
 
         except ValueError:
-            self.log.exception("Malformed json response")
+            logger.exception("Malformed json response")
         except KeyError:
-            self.log.exception("Unexpected content in Ansible Runner Service"
+            logger.exception("Unexpected content in Ansible Runner Service"
                                " response")
         except TypeError:
-            self.log.exception("Hosts data must be iterable in Ansible Runner "
+            logger.exception("Hosts data must be iterable in Ansible Runner "
                                "Service response")
 
         return inventory_nodes

--- a/src/pybind/mgr/ansible/tests/test_client_playbooks.py
+++ b/src/pybind/mgr/ansible/tests/test_client_playbooks.py
@@ -33,8 +33,7 @@ logger.addHandler(handler)
 def mock_get_pb(mock_server, playbook_name, return_code):
 
     ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                        client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                        logger = logger)
+                        client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
     the_pb_url = "https://%s/%s/%s" % (SERVER_URL, PLAYBOOK_EXEC_URL, playbook_name)
 
@@ -53,7 +52,7 @@ def mock_get_pb(mock_server, playbook_name, return_code):
                                "data": { "play_uuid": "1733c3ac" }},
                         status_code=return_code)
 
-    return PlayBookExecution(ars_client, playbook_name, logger,
+    return PlayBookExecution(ars_client, playbook_name,
                              result_pattern = "RESULTS")
 
 class ARSclientTest(unittest.TestCase):
@@ -62,8 +61,7 @@ class ARSclientTest(unittest.TestCase):
 
         with self.assertRaises(AnsibleRunnerServiceError):
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                            client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                            logger = logger)
+                            client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             status = ars_client.is_operative()
 
@@ -73,8 +71,7 @@ class ARSclientTest(unittest.TestCase):
         with requests_mock.Mocker() as mock_server:
 
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                                logger = logger)
+                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             the_api_url = "https://%s/%s" % (SERVER_URL,API_URL)
             mock_server.register_uri("GET",
@@ -90,8 +87,7 @@ class ARSclientTest(unittest.TestCase):
         with requests_mock.Mocker() as mock_server:
 
             ars_client = Client(SERVER_URL, verify_server=False, ca_bundle="",
-                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH",
-                                logger = logger)
+                                client_cert = "DUMMY_PATH", client_key = "DUMMY_PATH")
 
             url = "https://%s/test" % (SERVER_URL)
             mock_server.register_uri("DELETE",

--- a/src/pybind/mgr/ansible/tests/test_output_wizards.py
+++ b/src/pybind/mgr/ansible/tests/test_output_wizards.py
@@ -24,8 +24,7 @@ class  OutputWizardProcessHostsList(unittest.TestCase):
                 }
                 """
     ar_client = mock.Mock()
-    logger = mock.Mock()
-    test_wizard = ProcessHostsList(ar_client, logger)
+    test_wizard = ProcessHostsList(ar_client)
 
     def test_process(self):
         """Test a normal call"""
@@ -64,9 +63,7 @@ class OutputWizardProcessPlaybookResult(unittest.TestCase):
     ar_client = mock.Mock()
     ar_client.http_get = mock.MagicMock(return_value=mocked_response)
 
-    logger = mock.Mock()
-
-    test_wizard = ProcessPlaybookResult(ar_client, logger)
+    test_wizard = ProcessPlaybookResult(ar_client)
 
     def test_process(self):
         """Test a normal call
@@ -177,9 +174,7 @@ class OutputWizardProcessInventory(unittest.TestCase):
     ar_client = mock.Mock()
     ar_client.http_get = mock.MagicMock(return_value=mocked_response)
 
-    logger = mock.Mock()
-
-    test_wizard = ProcessInventory(ar_client, logger)
+    test_wizard = ProcessInventory(ar_client)
 
     def test_process(self):
         """Test a normal call

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -272,29 +272,24 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             return c
 
-    def wait(self, completions):
-        incomplete = False
+    def process(self, completions):
+        """
+        Does nothing, as completions are processed in another thread.
+        """
 
-        with self._completion_lock:
-            for c in completions:
-                if c.is_complete:
-                    continue
-                if not c.is_complete:
-                    # TODO: the job is in the bus, it should reach us eventually
-                    # unless something has gone wrong (e.g. salt-api died, etc.),
-                    # in which case it's possible the job finished but we never
-                    # noticed the salt/run/$id/ret event.  Need to add the job ID
-                    # (or possibly the full event tag) to the completion object.
-                    # That way, if we want to double check on a job that hasn't
-                    # been completed yet, we can make a synchronous request to
-                    # salt-api to invoke jobs.lookup_jid, and if it's complete we
-                    # should be able to pass its return value to _process_result()
-                    # Question: do we do this automatically after some timeout?
-                    # Or do we add a function so the admin can check and "unstick"
-                    # a stuck completion?
-                    incomplete = True
-
-        return not incomplete
+        # If the job is still incomplete:
+        # TODO: the job is in the bus, it should reach us eventually
+        # unless something has gone wrong (e.g. salt-api died, etc.),
+        # in which case it's possible the job finished but we never
+        # noticed the salt/run/$id/ret event.  Need to add the job ID
+        # (or possibly the full event tag) to the completion object.
+        # That way, if we want to double check on a job that hasn't
+        # been completed yet, we can make a synchronous request to
+        # salt-api to invoke jobs.lookup_jid, and if it's complete we
+        # should be able to pass its return value to _process_result()
+        # Question: do we do this automatically after some timeout?
+        # Or do we add a function so the admin can check and "unstick"
+        # a stuck completion?
 
 
     def handle_command(self, inbuf, cmd):

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -40,7 +40,7 @@ class DeepSeaReadCompletion(orchestrator.ReadCompletion):
         return self._result
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._complete
 
 

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -150,7 +150,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             return result
 
         with self._completion_lock:
-            c = DeepSeaReadCompletion(process_result)
+            c = DeepSeaReadCompletion(on_complete=process_result)
 
             nodes = []
             roles = []
@@ -249,7 +249,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             return result
 
         with self._completion_lock:
-            c = DeepSeaReadCompletion(process_result)
+            c = DeepSeaReadCompletion(on_complete=process_result)
 
             # Always request all services, so we always have all services cached.
             resp = self._do_request_with_login("POST", data = {

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -10,7 +10,10 @@ ceph-mgr DeepSea orchestrator module
 
 import json
 import errno
-from typing import Dict
+try:
+    from typing import Dict
+except ImportError:
+    pass  # type checking
 
 import requests
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -652,6 +652,14 @@ class Orchestrator(object):
                     }
         return features
 
+    @_hide_in_features
+    def cancel_completions(self):
+        # type: () -> None
+        """
+        Cancels ongoing completions. Unstuck the mgr.
+        """
+        raise NotImplementedError()
+
     def add_host(self, host):
         # type: (str) -> Completion
         """

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -294,13 +294,16 @@ class ProgressReference(object):
                  completion=None  # type: Optional[Callable[[], Completion[float]]]
                 ):
         """
-        ProgressReference can be used within Completions:
+        ProgressReference can be used within Completions::
 
-        +---------------+      +---------------------------------+
-        |               | then |                                 |
-        | My Completion | +--> | on_complete=ProgressReference() |
-        |               |      |                                 |
-        +---------------+      +---------------------------------+
+            +---------------+      +---------------------------------+
+            |               | then |                                 |
+            | My Completion | +--> | on_complete=ProgressReference() |
+            |               |      |                                 |
+            +---------------+      +---------------------------------+
+
+        See :func:`Completion.with_progress` for an easy way to create
+        a progress reference
 
         """
         super(ProgressReference, self).__init__()
@@ -369,11 +372,34 @@ class ProgressReference(object):
         self._completion_has_result = True
         self.progress = 1
 
+
 class Completion(_Promise[T]):
     """
     Combines multiple promises into one overall operation.
 
-    :ivar exception: Holds an exception object, if the completion errored.
+    Completions are composable by being able to
+    call one completion from another completion. I.e. making them re-usable
+    using Promises E.g.::
+
+        >>> return Orchestrator().get_hosts().then(self._create_osd)
+
+    where ``get_hosts`` returns a Completion of list of hosts and
+    ``_create_osd`` takes a list of hosts.
+
+    The concept behind this is to store the computation steps
+    explicit and then explicitly evaluate the chain:
+
+        >>> p = Completion(on_complete=lambda x: x*2).then(on_complete=lambda x: str(x))
+        ... p.finalize(2)
+        ... assert p.result = "4"
+
+    or graphically::
+
+        +---------------+      +-----------------+
+        |               | then |                 |
+        | lambda x: x*x | +--> | lambda x: str(x)|
+        |               |      |                 |
+        +---------------+      +-----------------+
 
     """
     def __init__(self,

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -26,17 +26,10 @@ from mgr_util import format_bytes
 try:
     from ceph.deployment.drive_group import DriveGroupSpec
     from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, Type
-
 except ImportError:
     pass
-    #T, G = object, object
 
-T = TypeVar('T')
-U = TypeVar('U')
-V = TypeVar('V')
-G = Generic[T]
-Promises = TypeVar('Promises', bound='_Promise')
-Completions = TypeVar('Completions', bound='Completion')
+logger = logging.getLogger(__name__)
 
 
 
@@ -133,7 +126,7 @@ def _no_result():
     return object()
 
 
-class _Promise(Generic[T]):
+class _Promise(object):
     """
     A completion may need multiple promises to be fulfilled. `_Promise` is one
     step.
@@ -150,12 +143,12 @@ class _Promise(Generic[T]):
     NO_RESULT = _no_result()  # type: None
 
     def __init__(self,
-                 _first_promise=None,  # type: Optional["_Promise[V]"]
-                 value=NO_RESULT,  # type: Optional[T]
-                 on_complete=None    # type: Optional[Callable[[T], Union[U, _Promise[U]]]]
+                 _first_promise=None,  # type: Optional["_Promise"]
+                 value=NO_RESULT,  # type: Optional
+                 on_complete=None    # type: Optional[Callable]
                  ):
         self._on_complete = on_complete
-        self._next_promise = None  # type: Optional[_Promise[U]]
+        self._next_promise = None  # type: Optional[_Promise]
 
         self._state = self.INITIALIZED
         self._exception = None  # type: Optional[Exception]
@@ -175,7 +168,7 @@ class _Promise(Generic[T]):
         )
 
     def then(self, on_complete):
-        # type: (Promises, Callable[[T], Union[U, _Promise[U]]]) -> Promises[U]
+        # type: (Any, Callable) -> Any
         """
         Call ``on_complete`` as soon as this promise is finalized.
         """
@@ -194,7 +187,7 @@ class _Promise(Generic[T]):
             return self._next_promise
 
     def _set_next_promise(self, next):
-        # type: (_Promise[U]) -> None
+        # type: (_Promise) -> None
         assert self is not next
         assert self._state is self.INITIALIZED
 
@@ -204,7 +197,6 @@ class _Promise(Generic[T]):
             p._first_promise = self._first_promise
 
     def finalize(self, value=NO_RESULT):
-        # type: (Optional[T]) -> None
         """
         Sets this promise to complete.
 
@@ -291,7 +283,7 @@ class ProgressReference(object):
     def __init__(self,
                  message,  # type: str
                  mgr,
-                 completion=None  # type: Optional[Callable[[], Completion[float]]]
+                 completion=None  # type: Optional[Callable[[], Completion]]
                 ):
         """
         ProgressReference can be used within Completions::
@@ -314,7 +306,7 @@ class ProgressReference(object):
         #: The completion can already have a result, before the write
         #: operation is effective. progress == 1 means, the services are
         #: created / removed.
-        self.completion = completion  # type: Optional[Callable[[], Completion[float]]]
+        self.completion = completion  # type: Optional[Callable[[], Completion]]
 
         #: if a orchestrator module can provide a more detailed
         #: progress information, it needs to also call ``progress.update()``.
@@ -373,7 +365,7 @@ class ProgressReference(object):
         self.progress = 1
 
 
-class Completion(_Promise[T]):
+class Completion(_Promise):
     """
     Combines multiple promises into one overall operation.
 
@@ -403,9 +395,9 @@ class Completion(_Promise[T]):
 
     """
     def __init__(self,
-                 _first_promise=None,  # type: Optional["Completion[V]"]
-                 value=_Promise.NO_RESULT,  # type: Optional[T]
-                 on_complete=None  # type: Optional[Callable[[T], Union[U, Completion[U]]]]
+                 _first_promise=None,  # type: Optional["Completion"]
+                 value=_Promise.NO_RESULT,  # type: Any
+                 on_complete=None  # type: Optional[Callable]
                  ):
         super(Completion, self).__init__(_first_promise, value, on_complete)
 
@@ -431,15 +423,15 @@ class Completion(_Promise[T]):
         return None
 
     @classmethod
-    def with_progress(cls,  # type: Completions[T]
+    def with_progress(cls,  # type: Any
                       message,  # type: str
                       mgr,
-                      _first_promise=None,  # type: Optional["Completions[V]"]
-                      value=_Promise.NO_RESULT,  # type: Optional[T]
-                      on_complete=None,  # type: Optional[Callable[[T], Union[U, Completions[U]]]]
-                      calc_percent=None  # type: Optional[Callable[[], Completions[float]]]
+                      _first_promise=None,  # type: Optional["Completions"]
+                      value=_Promise.NO_RESULT,  # type: Any
+                      on_complete=None,  # type: Optional[Callable]
+                      calc_percent=None  # type: Optional[Callable[[], Any]]
                       ):
-        # type: (...) -> Completions[T]
+        # type: (...) -> Any
 
         c = cls(
             _first_promise=_first_promise,
@@ -560,7 +552,7 @@ def raise_if_exception(c):
         raise e
 
 
-class TrivialReadCompletion(Completion[T]):
+class TrivialReadCompletion(Completion):
     """
     This is the trivial completion simply wrapping a result.
     """
@@ -705,7 +697,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def get_hosts(self):
-        # type: () -> Completion[List[InventoryNode]]
+        # type: () -> Completion
         """
         Report the hosts in the cluster.
 
@@ -716,7 +708,7 @@ class Orchestrator(object):
         return self.get_inventory()
 
     def get_inventory(self, node_filter=None, refresh=False):
-        # type: (InventoryFilter, bool) -> Completion[List[InventoryNode]]
+        # type: (InventoryFilter, bool) -> Completion
         """
         Returns something that was created by `ceph-volume inventory`.
 
@@ -725,7 +717,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def describe_service(self, service_type=None, service_id=None, node_name=None, refresh=False):
-        # type: (Optional[str], Optional[str], Optional[str], bool) -> Completion[List[ServiceDescription]]
+        # type: (Optional[str], Optional[str], Optional[str], bool) -> Completion
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -901,7 +893,7 @@ class Orchestrator(object):
 
     @_hide_in_features
     def upgrade_status(self):
-        # type: () -> Completion[UpgradeStatusSpec]
+        # type: () -> Completion
         """
         If an upgrade is currently underway, report on where
         we are in the process, or if some error has occurred.
@@ -912,7 +904,7 @@ class Orchestrator(object):
 
     @_hide_in_features
     def upgrade_available(self):
-        # type: () -> Completion[List[str]]
+        # type: () -> Completion
         """
         Report on what versions are available to upgrade to
 

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -319,6 +319,10 @@ class Orchestrator(object):
     internet downloads.  For that reason, all are asynchronous, and return
     ``Completion`` objects.
 
+    Methods should only return the completion and not directly execute
+    anything, like network calls. Otherwise the purpose of
+    those completions is defeated.
+
     Implementations are not required to start work on an operation until
     the caller waits on the relevant Completion objects.  Callers making
     multiple updates should not wait on Completions until they're done
@@ -368,19 +372,18 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     @_hide_in_features
-    def wait(self, completions):
+    def process(self, completions):
+        # type: (List[_Completion]) -> None
         """
-        Given a list of Completion instances, progress any which are
-        incomplete.  Return a true if everything is done.
+        Given a list of Completion instances, process any which are
+        incomplete.
 
         Callers should inspect the detail of each completion to identify
         partial completion/progress information, and present that information
         to the user.
 
-        For fast operations (e.g. reading from a database), implementations
-        may choose to do blocking IO in this call.
-
-        :rtype: bool
+        This method should not block, as this would make it slow to query
+        a status, while other long running operations are in progress.
         """
         raise NotImplementedError()
 
@@ -1016,6 +1019,12 @@ class OrchestratorClientMixin(Orchestrator):
 
         self.__mgr = mgr  # Make sure we're not overwriting any other `mgr` properties
 
+    def __get_mgr(self):
+        try:
+            return self.__mgr
+        except AttributeError:
+            return self
+
     def _oremote(self, meth, args, kwargs):
         """
         Helper for invoking `remote` on whichever orchestrator is enabled
@@ -1024,10 +1033,8 @@ class OrchestratorClientMixin(Orchestrator):
         :raises OrchestratorError: orchestrator failed to perform
         :raises ImportError: no `orchestrator_cli` module or backend not found.
         """
-        try:
-            mgr = self.__mgr
-        except AttributeError:
-            mgr = self
+        mgr = self.__get_mgr()
+
         try:
             o = mgr._select_orchestrator()
         except AttributeError:
@@ -1066,11 +1073,15 @@ class OrchestratorClientMixin(Orchestrator):
 
         :param completions: List of Completions
         :raises NoOrchestrator:
+        :raises RuntimeError: something went wrong while calling the process method.
         :raises ImportError: no `orchestrator_cli` module or backend not found.
         """
         for c in completions:
             self._update_completion_progress(c)
-        while not self.wait(completions):
+        while any(not c.is_complete for c in completions):
+            self.wait(completions)
+            self.__get_mgr().log.info("Operations pending: %s",
+                                      sum(1 for c in completions if not c.is_complete))
             if any(c.should_wait for c in completions):
                 time.sleep(1)
             else:

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -4,6 +4,8 @@ ceph-mgr orchestrator interface
 
 Please see the ceph-mgr module developer's guide for more information.
 """
+import functools
+import logging
 import sys
 import time
 from collections import namedtuple
@@ -23,12 +25,19 @@ from mgr_util import format_bytes
 
 try:
     from ceph.deployment.drive_group import DriveGroupSpec
-    from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator
+    from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, Type
 
-    T = TypeVar('T')
-    G = Generic[T]
 except ImportError:
-    T, G = object, object
+    pass
+    #T, G = object, object
+
+T = TypeVar('T')
+U = TypeVar('U')
+V = TypeVar('V')
+G = Generic[T]
+Promises = TypeVar('Promises', bound='_Promise')
+Completions = TypeVar('Completions', bound='Completion')
+
 
 
 def parse_host_specs(host, require_network=True):
@@ -120,19 +129,323 @@ class OrchestratorValidationError(OrchestratorError):
     Raised when an orchestrator doesn't support a specific feature.
     """
 
+def _no_result():
+    return object()
 
-class _Completion(G):
+
+class _Promise(Generic[T]):
+    """
+    A completion may need multiple promises to be fulfilled. `_Promise` is one
+    step.
+
+    Typically ``Orchestrator`` implementations inherit from this class to
+    build their own way of finishing a step to fulfil a future.
+
+    They are not exposed in the orchestrator interface and can be seen as a
+    helper to build orchestrator modules.
+    """
+    INITIALIZED = 1  # We have a parent completion and a next completion
+    FINISHED = 2  # we have a final result
+
+    NO_RESULT = _no_result()  # type: None
+
+    def __init__(self,
+                 _first_promise=None,  # type: Optional["_Promise[V]"]
+                 value=NO_RESULT,  # type: Optional[T]
+                 on_complete=None    # type: Optional[Callable[[T], Union[U, _Promise[U]]]]
+                 ):
+        self._on_complete = on_complete
+        self._next_promise = None  # type: Optional[_Promise[U]]
+
+        self._state = self.INITIALIZED
+        self._exception = None  # type: Optional[Exception]
+
+        # Value of this _Promise. may be an intermediate result.
+        self._value = value
+
+        # _Promise is not a continuation monad, as `_result` is of type
+        # T instead of (T -> r) -> r. Therefore we need to store the first promise here.
+        self._first_promise = _first_promise or self  # type: 'Completion'
+
+    def __repr__(self):
+        name = getattr(self._on_complete, '__name__', '??') if self._on_complete else 'None'
+        val = repr(self._value) if self._value is not self.NO_RESULT else 'NA'
+        return '{}(_s={}, val={}, id={}, name={}, pr={}, _next={})'.format(
+            self.__class__, self._state, val, id(self), name, getattr(next, '_progress_reference', 'NA'), repr(self._next_promise)
+        )
+
+    def then(self, on_complete):
+        # type: (Promises, Callable[[T], Union[U, _Promise[U]]]) -> Promises[U]
+        """
+        Call ``on_complete`` as soon as this promise is finalized.
+        """
+        assert self._state is self.INITIALIZED
+        if self._on_complete is not None:
+            assert self._next_promise is None
+            self._set_next_promise(self.__class__(
+                _first_promise=self._first_promise,
+                on_complete=on_complete
+            ))
+            return self._next_promise
+
+        else:
+            self._on_complete = on_complete
+            self._set_next_promise(self.__class__(_first_promise=self._first_promise))
+            return self._next_promise
+
+    def _set_next_promise(self, next):
+        # type: (_Promise[U]) -> None
+        assert self is not next
+        assert self._state is self.INITIALIZED
+
+        self._next_promise = next
+        assert self._next_promise is not None
+        for p in iter(self._next_promise):
+            p._first_promise = self._first_promise
+
+    def finalize(self, value=NO_RESULT):
+        # type: (Optional[T]) -> None
+        """
+        Sets this promise to complete.
+
+        Orchestrators may choose to use this helper function.
+
+        :param value: new value.
+        """
+        assert self._state is self.INITIALIZED
+
+        if value is not self.NO_RESULT:
+            self._value = value
+        assert self._value is not self.NO_RESULT
+
+        if self._on_complete:
+            try:
+                next_result = self._on_complete(self._value)
+            except Exception as e:
+                self.fail(e)
+                return
+        else:
+            next_result = self._value
+
+        if isinstance(next_result, _Promise):
+            # hack: _Promise is not a continuation monad.
+            next_result = next_result._first_promise  # type: ignore
+            assert next_result not in self, repr(self._first_promise) + repr(next_result)
+            assert self not in next_result
+            next_result._append_promise(self._next_promise)
+            self._set_next_promise(next_result)
+            if self._next_promise._value is self.NO_RESULT:
+                self._next_promise._value = self._value
+        else:
+            # simple map. simply forward
+            if self._next_promise:
+                self._next_promise._value = next_result
+            else:
+                # Hack: next_result is of type U, _value is of type T
+                self._value = next_result  # type: ignore
+        self._state = self.FINISHED
+        logger.debug('finalized {}'.format(repr(self)))
+        self.propagate_to_next()
+
+    def propagate_to_next(self):
+        assert self._state is self.FINISHED
+        if self._next_promise:
+            self._next_promise.finalize()
+
+    def fail(self, e):
+        # type: (Exception) -> None
+        """
+        Sets the whole completion to be faild with this exception and end the
+        evaluation.
+        """
+        assert self._state is self.INITIALIZED
+        logger.exception('_Promise failed')
+        self._exception = e
+        self._value = 'exception'
+        if self._next_promise:
+            self._next_promise.fail(e)
+        self._state = self.FINISHED
+
+    def __contains__(self, item):
+        return any(item is p for p in iter(self._first_promise))
+
+    def __iter__(self):
+        yield self
+        elem = self._next_promise
+        while elem is not None:
+            yield elem
+            elem = elem._next_promise
+
+    def _append_promise(self, other):
+        if other is not None:
+            assert self not in other
+            assert other not in self
+            self._last_promise()._set_next_promise(other)
+
+    def _last_promise(self):
+        # type: () -> _Promise
+        return list(iter(self))[-1]
+
+
+class ProgressReference(object):
+    def __init__(self,
+                 message,  # type: str
+                 mgr,
+                 completion=None  # type: Optional[Callable[[], Completion[float]]]
+                ):
+        """
+        ProgressReference can be used within Completions:
+
+        +---------------+      +---------------------------------+
+        |               | then |                                 |
+        | My Completion | +--> | on_complete=ProgressReference() |
+        |               |      |                                 |
+        +---------------+      +---------------------------------+
+
+        """
+        super(ProgressReference, self).__init__()
+        self.progress_id = str(uuid.uuid4())
+        self.message = message
+        self.mgr = mgr
+
+        #: The completion can already have a result, before the write
+        #: operation is effective. progress == 1 means, the services are
+        #: created / removed.
+        self.completion = completion  # type: Optional[Callable[[], Completion[float]]]
+
+        #: if a orchestrator module can provide a more detailed
+        #: progress information, it needs to also call ``progress.update()``.
+        self.progress = 0.0
+
+        self._completion_has_result = False
+        self.mgr.all_progress_references.append(self)
+
+    def __str__(self):
+        """
+        ``__str__()`` is used for determining the message for progress events.
+        """
+        return self.message or super(ProgressReference, self).__str__()
+
+    def __call__(self, arg):
+        self._completion_has_result = True
+        if self.progress == 0.0:
+            self.progress = 0.5
+        return arg
+
+    @property
+    def progress(self):
+        return self._progress
+
+    @progress.setter
+    def progress(self, progress):
+        self._progress = progress
+        try:
+            if self.effective:
+                self.mgr.remote("progress", "complete", self.progress_id)
+                self.mgr.all_progress_references = [p for p in self.mgr.all_progress_references if p is not self]
+            else:
+                self.mgr.remote("progress", "update", self.progress_id, self.message,
+                                progress,
+                                [("origin", "orchestrator")])
+        except ImportError:
+            # If the progress module is disabled that's fine,
+            # they just won't see the output.
+            pass
+
+    @property
+    def effective(self):
+        return self.progress == 1 and self._completion_has_result
+
+    def update(self):
+        def run(progress):
+            self.progress = progress
+        if self.completion:
+            c = self.completion().then(run)
+            self.mgr.process([c._first_promise])
+        else:
+            self.progress = 1
+
+    def fail(self):
+        self._completion_has_result = True
+        self.progress = 1
+
+class Completion(_Promise[T]):
+    """
+    Combines multiple promises into one overall operation.
+
+    :ivar exception: Holds an exception object, if the completion errored.
+
+    """
+    def __init__(self,
+                 _first_promise=None,  # type: Optional["Completion[V]"]
+                 value=_Promise.NO_RESULT,  # type: Optional[T]
+                 on_complete=None  # type: Optional[Callable[[T], Union[U, Completion[U]]]]
+                 ):
+        super(Completion, self).__init__(_first_promise, value, on_complete)
+
+    @property
+    def _progress_reference(self):
+        # type: () -> Optional[ProgressReference]
+        if hasattr(self._on_complete, 'progress_id'):
+            return self._on_complete
+        return None
+
+    @property
+    def progress_reference(self):
+        # type: () -> Optional[ProgressReference]
+        """
+        ProgressReference. Marks this completion
+        as a write completeion.
+        """
+
+        references = [c._progress_reference for c in iter(self) if c._progress_reference is not None]
+        if references:
+            assert len(references) == 1
+            return references[0]
+        return None
+
+    @classmethod
+    def with_progress(cls,  # type: Completions[T]
+                      message,  # type: str
+                      mgr,
+                      _first_promise=None,  # type: Optional["Completions[V]"]
+                      value=_Promise.NO_RESULT,  # type: Optional[T]
+                      on_complete=None,  # type: Optional[Callable[[T], Union[U, Completions[U]]]]
+                      calc_percent=None  # type: Optional[Callable[[], Completions[float]]]
+                      ):
+        # type: (...) -> Completions[T]
+
+        c = cls(
+            _first_promise=_first_promise,
+            value=value,
+            on_complete=on_complete
+        ).then(
+            on_complete=ProgressReference(
+                message=message,
+                mgr=mgr,
+                completion=calc_percent
+            )
+        )
+        return c._first_promise
+
+    def fail(self, e):
+        super(Completion, self).fail(e)
+        if self._progress_reference:
+            self._progress_reference.fail()
+
     @property
     def result(self):
-        # type: () -> T
         """
-        Return the result of the operation that we were waited
-        for.  Only valid after calling Orchestrator.wait() on this
+        The result of the operation that we were waited
+        for.  Only valid after calling Orchestrator.process() on this
         completion.
         """
-        raise NotImplementedError()
+        last = self._last_promise()
+        assert last._state == _Promise.FINISHED
+        return last._value
 
     def result_str(self):
+        """Force a string."""
         if self.result is None:
             return ''
         return str(self.result)
@@ -140,27 +453,24 @@ class _Completion(G):
     @property
     def exception(self):
         # type: () -> Optional[Exception]
-        """
-        Holds an exception object.
-        """
-        try:
-            return self.__exception
-        except AttributeError:
-            return None
-
-    @exception.setter
-    def exception(self, value):
-        self.__exception = value
+        return self._last_promise()._exception
 
     @property
-    def is_read(self):
+    def has_result(self):
         # type: () -> bool
-        raise NotImplementedError()
+        """
+        Has the operation already a result?
 
-    @property
-    def is_complete(self):
-        # type: () -> bool
-        raise NotImplementedError()
+        For Write operations, it can already have a
+        result, if the orchestrator's configuration is
+        persistently written. Typically this would
+        indicate that an update had been written to
+        a manifest, but that the update had not
+        necessarily been pushed out to the cluster.
+
+        :return:
+        """
+        return self._last_promise()._state == _Promise.FINISHED
 
     @property
     def is_errored(self):
@@ -172,13 +482,28 @@ class _Completion(G):
         return self.exception is not None
 
     @property
-    def should_wait(self):
+    def needs_result(self):
         # type: () -> bool
-        raise NotImplementedError()
+        """
+        Could the external operation be deemed as complete,
+        or should we wait?
+        We must wait for a read operation only if it is not complete.
+        """
+        return not self.is_errored and not self.has_result
+
+    @property
+    def is_finished(self):
+        # type: () -> bool
+        """
+        Could the external operation be deemed as complete,
+        or should we wait?
+        We must wait for a read operation only if it is not complete.
+        """
+        return self.is_errored or (self.has_result)
 
 
 def raise_if_exception(c):
-    # type: (_Completion) -> None
+    # type: (Completion) -> None
     """
     :raises OrchestratorError: Some user error or a config error.
     :raises Exception: Some internal error
@@ -209,102 +534,13 @@ def raise_if_exception(c):
         raise e
 
 
-class ReadCompletion(_Completion):
-    """
-    ``Orchestrator`` implementations should inherit from this
-    class to implement their own handles to operations in progress, and
-    return an instance of their subclass from calls into methods.
-    """
-
-    def __init__(self):
-        pass
-
-    @property
-    def is_read(self):
-        return True
-
-    @property
-    def should_wait(self):
-        """Could the external operation be deemed as complete,
-        or should we wait?
-        We must wait for a read operation only if it is not complete.
-        """
-        return not self.is_complete
-
-
-class TrivialReadCompletion(ReadCompletion):
+class TrivialReadCompletion(Completion[T]):
     """
     This is the trivial completion simply wrapping a result.
     """
     def __init__(self, result):
         super(TrivialReadCompletion, self).__init__()
         self._result = result
-
-    @property
-    def result(self):
-        return self._result
-
-    @property
-    def is_complete(self):
-        return True
-
-
-class WriteCompletion(_Completion):
-    """
-    ``Orchestrator`` implementations should inherit from this
-    class to implement their own handles to operations in progress, and
-    return an instance of their subclass from calls into methods.
-    """
-
-    def __init__(self):
-        self.progress_id = str(uuid.uuid4())
-
-        #: if a orchestrator module can provide a more detailed
-        #: progress information, it needs to also call ``progress.update()``.
-        self.progress = 0.5
-
-    def __str__(self):
-        """
-        ``__str__()`` is used for determining the message for progress events.
-        """
-        return super(WriteCompletion, self).__str__()
-
-    @property
-    def is_persistent(self):
-        # type: () -> bool
-        """
-        Has the operation updated the orchestrator's configuration
-        persistently?  Typically this would indicate that an update
-        had been written to a manifest, but that the update
-        had not necessarily been pushed out to the cluster.
-        """
-        raise NotImplementedError()
-
-    @property
-    def is_effective(self):
-        """
-        Has the operation taken effect on the cluster?  For example,
-        if we were adding a service, has it come up and appeared
-        in Ceph's cluster maps?
-        """
-        raise NotImplementedError()
-
-    @property
-    def is_complete(self):
-        return self.is_errored or (self.is_persistent and self.is_effective)
-
-    @property
-    def is_read(self):
-        return False
-
-    @property
-    def should_wait(self):
-        """Could the external operation be deemed as complete,
-        or should we wait?
-        We must wait for a write operation only if we know
-        it is not persistent yet.
-        """
-        return not self.is_persistent
 
 
 def _hide_in_features(f):
@@ -373,7 +609,7 @@ class Orchestrator(object):
 
     @_hide_in_features
     def process(self, completions):
-        # type: (List[_Completion]) -> None
+        # type: (List[Completion]) -> None
         """
         Given a list of Completion instances, process any which are
         incomplete.
@@ -417,7 +653,7 @@ class Orchestrator(object):
         return features
 
     def add_host(self, host):
-        # type: (str) -> WriteCompletion
+        # type: (str) -> Completion
         """
         Add a host to the orchestrator inventory.
 
@@ -426,7 +662,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def remove_host(self, host):
-        # type: (str) -> WriteCompletion
+        # type: (str) -> Completion
         """
         Remove a host from the orchestrator inventory.
 
@@ -435,7 +671,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def get_hosts(self):
-        # type: () -> ReadCompletion[List[InventoryNode]]
+        # type: () -> Completion[List[InventoryNode]]
         """
         Report the hosts in the cluster.
 
@@ -446,7 +682,7 @@ class Orchestrator(object):
         return self.get_inventory()
 
     def get_inventory(self, node_filter=None, refresh=False):
-        # type: (InventoryFilter, bool) -> ReadCompletion[List[InventoryNode]]
+        # type: (InventoryFilter, bool) -> Completion[List[InventoryNode]]
         """
         Returns something that was created by `ceph-volume inventory`.
 
@@ -455,7 +691,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def describe_service(self, service_type=None, service_id=None, node_name=None, refresh=False):
-        # type: (Optional[str], Optional[str], Optional[str], bool) -> ReadCompletion[List[ServiceDescription]]
+        # type: (Optional[str], Optional[str], Optional[str], bool) -> Completion[List[ServiceDescription]]
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -470,7 +706,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def service_action(self, action, service_type, service_name=None, service_id=None):
-        # type: (str, str, str, str) -> WriteCompletion
+        # type: (str, str, str, str) -> Completion
         """
         Perform an action (start/stop/reload) on a service.
 
@@ -485,15 +721,15 @@ class Orchestrator(object):
         :param service_type: e.g. "mds", "rgw", ...
         :param service_name: name of logical service ("cephfs", "us-east", ...)
         :param service_id: service daemon instance (usually a short hostname)
-        :rtype: WriteCompletion
+        :rtype: Completion
         """
-        assert action in ["start", "stop", "reload", "restart", "redeploy"]
-        assert service_name or service_id
-        assert not (service_name and service_id)
+        #assert action in ["start", "stop", "reload, "restart", "redeploy"]
+        #assert service_name or service_id
+        #assert not (service_name and service_id)
         raise NotImplementedError()
 
-    def create_osds(self, drive_group, all_hosts):
-        # type: (DriveGroupSpec, List[str]) -> WriteCompletion
+    def create_osds(self, drive_group):
+        # type: (DriveGroupSpec) -> Completion
         """
         Create one or more OSDs within a single Drive Group.
 
@@ -510,8 +746,8 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_osds(self, osd_ids, destroy=False):
-        # type: (List[str], bool) -> WriteCompletion
+    def remove_osds(self, osd_ids):
+        # type: (List[str]) -> Completion
         """
         :param osd_ids: list of OSD IDs
         :param destroy: marks the OSD as being destroyed. See :ref:`orchestrator-osd-replace`
@@ -533,7 +769,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_mgrs(self, num, hosts):
-        # type: (int, List[str]) -> WriteCompletion
+        # type: (int, List[str]) -> Completion
         """
         Update the number of cluster managers.
 
@@ -543,7 +779,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_mons(self, num, hosts):
-        # type: (int, List[Tuple[str,str]]) -> WriteCompletion
+        # type: (int, List[Tuple[str,str]]) -> Completion
         """
         Update the number of cluster monitors.
 
@@ -553,17 +789,17 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def add_mds(self, spec):
-        # type: (StatelessServiceSpec) -> WriteCompletion
+        # type: (StatelessServiceSpec) -> Completion
         """Create a new MDS cluster"""
         raise NotImplementedError()
 
     def remove_mds(self, name):
-        # type: (str) -> WriteCompletion
+        # type: (str) -> Completion
         """Remove an MDS cluster"""
         raise NotImplementedError()
 
     def update_mds(self, spec):
-        # type: (StatelessServiceSpec) -> WriteCompletion
+        # type: (StatelessServiceSpec) -> Completion
         """
         Update / redeploy existing MDS cluster
         Like for example changing the number of service instances.
@@ -589,17 +825,17 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def add_nfs(self, spec):
-        # type: (NFSServiceSpec) -> WriteCompletion
+        # type: (NFSServiceSpec) -> Completion
         """Create a new MDS cluster"""
         raise NotImplementedError()
 
     def remove_nfs(self, name):
-        # type: (str) -> WriteCompletion
+        # type: (str) -> Completion
         """Remove a NFS cluster"""
         raise NotImplementedError()
 
     def update_nfs(self, spec):
-        # type: (NFSServiceSpec) -> WriteCompletion
+        # type: (NFSServiceSpec) -> Completion
         """
         Update / redeploy existing NFS cluster
         Like for example changing the number of service instances.
@@ -607,17 +843,17 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def add_rgw(self, spec):
-        # type: (RGWSpec) -> WriteCompletion
+        # type: (RGWSpec) -> Completion
         """Create a new MDS zone"""
         raise NotImplementedError()
 
     def remove_rgw(self, zone):
-        # type: (str) -> WriteCompletion
+        # type: (str) -> Completion
         """Remove a RGW zone"""
         raise NotImplementedError()
 
     def update_rgw(self, spec):
-        # type: (StatelessServiceSpec) -> WriteCompletion
+        # type: (StatelessServiceSpec) -> Completion
         """
         Update / redeploy existing RGW zone
         Like for example changing the number of service instances.
@@ -626,12 +862,12 @@ class Orchestrator(object):
 
     @_hide_in_features
     def upgrade_start(self, upgrade_spec):
-        # type: (UpgradeSpec) -> WriteCompletion
+        # type: (UpgradeSpec) -> Completion
         raise NotImplementedError()
 
     @_hide_in_features
     def upgrade_status(self):
-        # type: () -> ReadCompletion[UpgradeStatusSpec]
+        # type: () -> Completion[UpgradeStatusSpec]
         """
         If an upgrade is currently underway, report on where
         we are in the process, or if some error has occurred.
@@ -642,7 +878,7 @@ class Orchestrator(object):
 
     @_hide_in_features
     def upgrade_available(self):
-        # type: () -> ReadCompletion[List[str]]
+        # type: () -> Completion[List[str]]
         """
         Report on what versions are available to upgrade to
 
@@ -964,6 +1200,11 @@ class InventoryNode(object):
     def __repr__(self):
         return "<InventoryNode>({name})".format(name=self.name)
 
+    @staticmethod
+    def get_host_names(nodes):
+        # type: (List[InventoryNode]) -> List[str]
+        return [node.name for node in nodes]
+
 
 class DeviceLightLoc(namedtuple('DeviceLightLoc', ['host', 'dev'])):
     """
@@ -984,7 +1225,6 @@ def _mk_orch_methods(cls):
     def shim(method_name):
         def inner(self, *args, **kwargs):
             completion = self._oremote(method_name, args, kwargs)
-            self._update_completion_progress(completion, 0)
             return completion
         return inner
 
@@ -1046,25 +1286,9 @@ class OrchestratorClientMixin(Orchestrator):
         mgr.log.debug("_oremote {} -> {}.{}(*{}, **{})".format(mgr.module_name, o, meth, args, kwargs))
         return mgr.remote(o, meth, *args, **kwargs)
 
-    def _update_completion_progress(self, completion, force_progress=None):
-        # type: (WriteCompletion, Optional[float]) -> None
-        try:
-            progress = force_progress if force_progress is not None else completion.progress
-            if completion.is_complete:
-                self.remote("progress", "complete", completion.progress_id)
-            else:
-                self.remote("progress", "update", completion.progress_id, str(completion), progress,
-                            [("origin", "orchestrator")])
-        except AttributeError:
-            # No WriteCompletion. Ignore.
-            pass
-        except ImportError:
-            # If the progress module is disabled that's fine,
-            # they just won't see the output.
-            pass
 
     def _orchestrator_wait(self, completions):
-        # type: (List[_Completion]) -> None
+        # type: (List[Completion]) -> None
         """
         Wait for completions to complete (reads) or
         become persistent (writes).
@@ -1076,18 +1300,14 @@ class OrchestratorClientMixin(Orchestrator):
         :raises RuntimeError: something went wrong while calling the process method.
         :raises ImportError: no `orchestrator_cli` module or backend not found.
         """
-        for c in completions:
-            self._update_completion_progress(c)
-        while any(not c.is_complete for c in completions):
-            self.wait(completions)
+        while any(not c.has_result for c in completions):
+            self.process(completions)
             self.__get_mgr().log.info("Operations pending: %s",
-                                      sum(1 for c in completions if not c.is_complete))
-            if any(c.should_wait for c in completions):
+                                      sum(1 for c in completions if not c.has_result))
+            if any(c.needs_result for c in completions):
                 time.sleep(1)
             else:
                 break
-        for c in completions:
-            self._update_completion_progress(c)
 
 
 class OutdatableData(object):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -171,6 +171,25 @@ class _Promise(object):
             self.__class__, self._state, val, self._on_complete, id(self), name, getattr(next, '_progress_reference', 'NA'), repr(self._next_promise)
         )
 
+    def pretty_print_1(self):
+        if self._name:
+            name = self._name
+        elif self._on_complete is None:
+            name = 'lambda x: x'
+        elif hasattr(self._on_complete, '__name__'):
+            name = getattr(self._on_complete, '__name__')
+        else:
+            name = self._on_complete.__class__.__name__
+        val = repr(self._value) if self._value not in (self.NO_RESULT, self.ASYNC_RESULT) else '...'
+        if hasattr(val, 'debug_str'):
+            val = val.debug_str()
+        prefix = {
+            self.INITIALIZED: '      ',
+            self.RUNNING:     '   >>>',
+            self.FINISHED:    '(done)'
+        }[self._state]
+        return '{} {}({}),'.format(prefix, name, val)
+
     def then(self, on_complete):
         # type: (Any, Callable) -> Any
         """
@@ -448,14 +467,22 @@ class Completion(_Promise):
             _first_promise=_first_promise,
             value=value,
             on_complete=on_complete
-        ).then(
+        ).add_progress(message, mgr, calc_percent)
+
+        return c._first_promise
+
+    def add_progress(self,
+                     message,  # type: str
+                     mgr,
+                     calc_percent=None  # type: Optional[Callable[[], Any]]
+                     ):
+        return self.then(
             on_complete=ProgressReference(
                 message=message,
                 mgr=mgr,
                 completion=calc_percent
             )
         )
-        return c._first_promise
 
     def fail(self, e):
         super(Completion, self).fail(e)
@@ -533,6 +560,16 @@ class Completion(_Promise):
         We must wait for a read operation only if it is not complete.
         """
         return self.is_errored or (self.has_result)
+
+    def pretty_print(self):
+
+        reprs = '\n'.join(p.pretty_print_1() for p in iter(self._first_promise))
+        return """<{}>[\n{}\n]""".format(self.__class__.__name__, reprs)
+
+
+def pretty_print(completions):
+    # type: (List[Completion]) -> str
+    return ', '.join(c.pretty_print() for c in completions)
 
 
 def raise_if_exception(c):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -610,7 +610,8 @@ class TrivialReadCompletion(Completion):
     """
     def __init__(self, result):
         super(TrivialReadCompletion, self).__init__()
-        self._result = result
+        if result:
+            self.finalize(result)
 
 
 def _hide_in_features(f):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -138,16 +138,20 @@ class _Promise(object):
     helper to build orchestrator modules.
     """
     INITIALIZED = 1  # We have a parent completion and a next completion
-    FINISHED = 2  # we have a final result
+    RUNNING = 2
+    FINISHED = 3  # we have a final result
 
     NO_RESULT = _no_result()  # type: None
+    ASYNC_RESULT = object()
 
     def __init__(self,
                  _first_promise=None,  # type: Optional["_Promise"]
                  value=NO_RESULT,  # type: Optional
-                 on_complete=None    # type: Optional[Callable]
+                 on_complete=None,    # type: Optional[Callable]
+                 name=None,  # type: Optional[str]
                  ):
         self._on_complete = on_complete
+        self._name = name
         self._next_promise = None  # type: Optional[_Promise]
 
         self._state = self.INITIALIZED
@@ -161,10 +165,10 @@ class _Promise(object):
         self._first_promise = _first_promise or self  # type: 'Completion'
 
     def __repr__(self):
-        name = getattr(self._on_complete, '__name__', '??') if self._on_complete else 'None'
+        name = self._name or getattr(self._on_complete, '__name__', '??') if self._on_complete else 'None'
         val = repr(self._value) if self._value is not self.NO_RESULT else 'NA'
-        return '{}(_s={}, val={}, id={}, name={}, pr={}, _next={})'.format(
-            self.__class__, self._state, val, id(self), name, getattr(next, '_progress_reference', 'NA'), repr(self._next_promise)
+        return '{}(_s={}, val={}, _on_c={}, id={}, name={}, pr={}, _next={})'.format(
+            self.__class__, self._state, val, self._on_complete, id(self), name, getattr(next, '_progress_reference', 'NA'), repr(self._next_promise)
         )
 
     def then(self, on_complete):
@@ -172,7 +176,7 @@ class _Promise(object):
         """
         Call ``on_complete`` as soon as this promise is finalized.
         """
-        assert self._state is self.INITIALIZED
+        assert self._state in (self.INITIALIZED, self.RUNNING)
         if self._on_complete is not None:
             assert self._next_promise is None
             self._set_next_promise(self.__class__(
@@ -189,14 +193,14 @@ class _Promise(object):
     def _set_next_promise(self, next):
         # type: (_Promise) -> None
         assert self is not next
-        assert self._state is self.INITIALIZED
+        assert self._state in (self.INITIALIZED, self.RUNNING)
 
         self._next_promise = next
         assert self._next_promise is not None
         for p in iter(self._next_promise):
             p._first_promise = self._first_promise
 
-    def finalize(self, value=NO_RESULT):
+    def _finalize(self, value=NO_RESULT):
         """
         Sets this promise to complete.
 
@@ -204,11 +208,13 @@ class _Promise(object):
 
         :param value: new value.
         """
-        assert self._state is self.INITIALIZED
+        assert self._state in (self.INITIALIZED, self.RUNNING)
+
+        self._state = self.RUNNING
 
         if value is not self.NO_RESULT:
             self._value = value
-        assert self._value is not self.NO_RESULT
+        assert self._value is not self.NO_RESULT, repr(self)
 
         if self._on_complete:
             try:
@@ -228,21 +234,25 @@ class _Promise(object):
             self._set_next_promise(next_result)
             if self._next_promise._value is self.NO_RESULT:
                 self._next_promise._value = self._value
-        else:
+            self.propagate_to_next()
+        elif next_result is not self.ASYNC_RESULT:
             # simple map. simply forward
             if self._next_promise:
                 self._next_promise._value = next_result
             else:
                 # Hack: next_result is of type U, _value is of type T
                 self._value = next_result  # type: ignore
-        self._state = self.FINISHED
-        logger.debug('finalized {}'.format(repr(self)))
-        self.propagate_to_next()
+            self.propagate_to_next()
+        else:
+            # asynchronous promise
+            pass
+
 
     def propagate_to_next(self):
-        assert self._state is self.FINISHED
+        self._state = self.FINISHED
+        logger.debug('finalized {}'.format(repr(self)))
         if self._next_promise:
-            self._next_promise.finalize()
+            self._next_promise._finalize()
 
     def fail(self, e):
         # type: (Exception) -> None
@@ -250,7 +260,7 @@ class _Promise(object):
         Sets the whole completion to be faild with this exception and end the
         evaluation.
         """
-        assert self._state is self.INITIALIZED
+        assert self._state in (self.INITIALIZED, self.RUNNING)
         logger.exception('_Promise failed')
         self._exception = e
         self._value = 'exception'
@@ -352,10 +362,10 @@ class ProgressReference(object):
         return self.progress == 1 and self._completion_has_result
 
     def update(self):
-        def run(progress):
+        def progress_run(progress):
             self.progress = progress
         if self.completion:
-            c = self.completion().then(run)
+            c = self.completion().then(progress_run)
             self.mgr.process([c._first_promise])
         else:
             self.progress = 1
@@ -397,9 +407,10 @@ class Completion(_Promise):
     def __init__(self,
                  _first_promise=None,  # type: Optional["Completion"]
                  value=_Promise.NO_RESULT,  # type: Any
-                 on_complete=None  # type: Optional[Callable]
+                 on_complete=None,  # type: Optional[Callable],
+                 name=None,  # type: Optional[str]
                  ):
-        super(Completion, self).__init__(_first_promise, value, on_complete)
+        super(Completion, self).__init__(_first_promise, value, on_complete, name)
 
     @property
     def _progress_reference(self):
@@ -450,6 +461,10 @@ class Completion(_Promise):
         super(Completion, self).fail(e)
         if self._progress_reference:
             self._progress_reference.fail()
+
+    def finalize(self, result=_Promise.NO_RESULT):
+        if self._first_promise._state == self.INITIALIZED:
+            self._first_promise._finalize(result)
 
     @property
     def result(self):
@@ -805,7 +820,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_mons(self, num, hosts):
-        # type: (int, List[Tuple[str,str]]) -> Completion
+        # type: (int, List[Tuple[str,str,str]]) -> Completion
         """
         Update the number of cluster monitors.
 
@@ -833,17 +848,17 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def add_rbd_mirror(self, spec):
-        # type: (StatelessServiceSpec) -> WriteCompletion
+        # type: (StatelessServiceSpec) -> Completion
         """Create rbd-mirror cluster"""
         raise NotImplementedError()
 
-    def remove_rbd_mirror(self):
-        # type: (str) -> WriteCompletion
+    def remove_rbd_mirror(self, name):
+        # type: (str) -> Completion
         """Remove rbd-mirror cluster"""
         raise NotImplementedError()
 
     def update_rbd_mirror(self, spec):
-        # type: (StatelessServiceSpec) -> WriteCompletion
+        # type: (StatelessServiceSpec) -> Completion
         """
         Update / redeploy rbd-mirror cluster
         Like for example changing the number of service instances.
@@ -1230,6 +1245,9 @@ class InventoryNode(object):
     def get_host_names(nodes):
         # type: (List[InventoryNode]) -> List[str]
         return [node.name for node in nodes]
+
+    def __eq__(self, other):
+        return self.name == other.name and self.devices == other.devices
 
 
 class DeviceLightLoc(namedtuple('DeviceLightLoc', ['host', 'dev'])):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -853,7 +853,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_rgw(self, spec):
-        # type: (StatelessServiceSpec) -> Completion
+        # type: (RGWSpec) -> Completion
         """
         Update / redeploy existing RGW zone
         Like for example changing the number of service instances.

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -326,19 +326,7 @@ Usage:
         else:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-        # TODO: Remove this and make the orchestrator composable
-        #   Like a future or so.
-        host_completion = self.get_hosts()
-        self._orchestrator_wait([host_completion])
-        orchestrator.raise_if_exception(host_completion)
-        all_hosts = [h.name for h in host_completion.result]
-
-        try:
-            drive_group.validate(all_hosts)
-        except DriveGroupValidationError as e:
-            return HandleCommandResult(-errno.EINVAL, stderr=str(e))
-
-        completion = self.create_osds(drive_group, all_hosts)
+        completion = self.create_osds(drive_group)
         self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         self.log.warning(str(completion.result))

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -673,3 +673,6 @@ Usage:
             assert False
         except orchestrator.OrchestratorError as e:
             assert e.args == ('hello', 'world')
+
+        c = orchestrator.TrivialReadCompletion(result=True)
+        assert c.has_result

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -628,6 +628,15 @@ Usage:
 
         return HandleCommandResult(-errno.EINVAL, stderr="Module '{0}' not found".format(module_name))
 
+    @_write_cli('orchestrator cancel',
+                desc='cancels ongoing operations')
+    def _cancel(self):
+        """
+        ProgressReferences might get stuck. Let's unstuck them.
+        """
+        self.cancel_completions()
+        return HandleCommandResult()
+
     @_read_cli('orchestrator status',
                desc='Report configured backend and its status')
     def _status(self):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -35,7 +35,7 @@ from .rook_cluster import RookCluster
 
 class RookCompletion(orchestrator.Completion):
     def evaluate(self):
-        self._first_promise.finalize(None)
+        self.finalize(None)
 
 
 def deferred_read(f):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -103,7 +103,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         # type: (List[RookCompletion]) -> None
 
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.evaluate()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -205,6 +205,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             self._shutdown.wait(5)
 
+    def cancel_completions(self):
+        for p in self.all_progress_references:
+            p.fail()
+        self.all_progress_references.clear()
+
     @deferred_read
     def get_inventory(self, node_filter=None, refresh=False):
         node_list = None

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -10,9 +10,6 @@ try:
 except ImportError:
     pass  # just for type checking
 
-T = TypeVar('T')
-
-
 try:
     from kubernetes import client, config
     from kubernetes.client.rest import ApiException
@@ -36,13 +33,13 @@ import orchestrator
 from .rook_cluster import RookCluster
 
 
-class RookCompletion(orchestrator.Completion[T]):
+class RookCompletion(orchestrator.Completion):
     def evaluate(self):
         self._first_promise.finalize(None)
 
 
 def deferred_read(f):
-    # type: (Callable[..., T]) -> Callable[..., RookCompletion[T]]
+    # type: (Callable) -> Callable[..., RookCompletion]
     """
     Decorator to make RookOrchestrator methods return
     a completion object that executes themselves.
@@ -55,12 +52,12 @@ def deferred_read(f):
     return wrapper
 
 
-def write_completion(on_complete,  # type: Callable[[], T]
+def write_completion(on_complete,  # type: Callable
                      message,  # type: str
                      mgr,
-                     calc_percent=None  # type: Optional[Callable[[], RookCompletion[float]]]
+                     calc_percent=None  # type: Optional[Callable[[], RookCompletion]]
                      ):
-    # type: (...) -> RookCompletion[T]
+    # type: (...) -> RookCompletion
     return RookCompletion.with_progress(
         message=message,
         mgr=mgr,

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -448,11 +448,11 @@ class Module(MgrModule):
         import orchestrator
         if what == 'OrchestratorError':
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.exception = orchestrator.OrchestratorError('hello', 'world')
+            c.fail(orchestrator.OrchestratorError('hello', 'world'))
             return c
         elif what == "ZeroDivisionError":
             c = orchestrator.TrivialReadCompletion(result=None)
-            c.exception = ZeroDivisionError('hello', 'world')
+            c.fail(ZeroDivisionError('hello', 'world'))
             return c
         assert False, repr(what)
 

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -380,7 +380,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         Does nothing, as completions are processed in another thread.
         """
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.finalize()

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -48,14 +48,19 @@ DEFAULT_SSH_CONFIG = ('Host *\n'
 
 
 class AsyncCompletion(orchestrator.Completion):
-    def __init__(self, *args, **kwargs):
-        self.__on_complete = None  # type: Callable
-        self.many = kwargs.pop('many', False)
-        super(AsyncCompletion, self).__init__(*args, **kwargs)
+    def __init__(self,
+                 _first_promise=None,  # type: Optional["Completion"]
+                 value=orchestrator._Promise.NO_RESULT,  # type: Any
+                 on_complete=None,  # type: Optional[Callable],
+                 name=None,  # type: Optional[str],
+                 many=False, # type: bool
+                 ):
 
-    def propagate_to_next(self):
-        # We don't have a synchronous result.
-        pass
+        assert SSHOrchestrator.instance is not None
+        self.many = many
+        if name is None and on_complete is not None:
+            name = on_complete.__name__
+        super(AsyncCompletion, self).__init__(_first_promise, value, on_complete, name)
 
     @property
     def _progress_reference(self):
@@ -70,19 +75,35 @@ class AsyncCompletion(orchestrator.Completion):
             return None
 
         def callback(result):
-            if self._next_promise:
-                self._next_promise._value = result
-            else:
-                self._value = result
-            super(AsyncCompletion, self).propagate_to_next()
+            try:
+                self.__on_complete = None
+                self._finalize(result)
+            except Exception as e:
+                self.fail(e)
+
+        def error_callback(e):
+            self.fail(e)
 
         def run(value):
             if self.many:
-                SSHOrchestrator.instance._worker_pool.map_async(self.__on_complete, value,
-                                                                callback=callback)
+                if not value:
+                    logger.info('calling map_async without values')
+                    callback([])
+                if six.PY3:
+                    SSHOrchestrator.instance._worker_pool.map_async(self.__on_complete, value,
+                                                                    callback=callback,
+                                                                    error_callback=error_callback)
+                else:
+                    SSHOrchestrator.instance._worker_pool.map_async(self.__on_complete, value,
+                                                                    callback=callback)
             else:
-                SSHOrchestrator.instance._worker_pool.apply_async(self.__on_complete, (value,),
-                                                                  callback=callback)
+                if six.PY3:
+                    SSHOrchestrator.instance._worker_pool.apply_async(self.__on_complete, (value,),
+                                                                      callback=callback, error_callback=error_callback)
+                else:
+                    SSHOrchestrator.instance._worker_pool.apply_async(self.__on_complete, (value,),
+                                                                      callback=callback)
+            return self.ASYNC_RESULT
 
         return run
 
@@ -99,8 +120,31 @@ def ssh_completion(cls=AsyncCompletion, **c_kwargs):
     """
     def decorator(f):
         @wraps(f)
-        def wrapper(*args, **kwargs):
-            return cls(on_complete=lambda _: f(*args, **kwargs), **c_kwargs)
+        def wrapper(*args):
+
+            name = f.__name__
+            many = c_kwargs.get('many', False)
+
+            # Some weired logic to make calling functions with multiple arguments work.
+            if len(args) == 1:
+                [value] = args
+                if many and value and isinstance(value[0], tuple):
+                    return cls(on_complete=lambda x: f(*x), value=value, name=name, **c_kwargs)
+                else:
+                    return cls(on_complete=f, value=value, name=name, **c_kwargs)
+            else:
+                if many:
+                    self, value = args
+
+                    def call_self(inner_args):
+                        if not isinstance(inner_args, tuple):
+                            inner_args = (inner_args, )
+                        return f(self, *inner_args)
+
+                    return cls(on_complete=call_self, value=value, name=name, **c_kwargs)
+                else:
+                    return cls(on_complete=lambda x: f(*x), value=args, name=name, **c_kwargs)
+
 
         return wrapper
     return decorator
@@ -113,12 +157,28 @@ def async_completion(f):
 
 def async_map_completion(f):
     # type: (Callable) -> Callable[..., AsyncCompletion]
+    """
+    kind of similar to
+
+    >>> def sync_map(f):
+    ...     return lambda x: map(f, x)
+
+    Limitation: This does not work, as you cannot return completions form `f`
+
+    >>> @async_map_completion
+    ... def run(x):
+    ...     return async_completion(str)(x)
+    """
     return ssh_completion(many=True)(f)
 
 
 def trivial_completion(f):
     # type: (Callable) -> Callable[..., orchestrator.Completion]
     return ssh_completion(cls=orchestrator.Completion)(f)
+
+
+def trivial_result(val):
+    return AsyncCompletion(value=val, name='trivial_result')
 
 
 class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
@@ -172,7 +232,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         try:
             with open(path, 'r') as f:
                 self._ceph_daemon = f.read()
-        except IOError as e:
+        except (IOError, TypeError) as e:
             raise RuntimeError("unable to read ceph-daemon at '%s': %s" % (
                 path, str(e)))
 
@@ -203,6 +263,12 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             if h not in self.service_cache:
                 self.log.debug('adding service item for %s' % h)
                 self.service_cache[h] = orchestrator.OutdatableData()
+
+    def shutdown(self):
+        self.log.error('ssh: shutdown')
+        self._worker_pool.close()
+        self._worker_pool.join()
+        self._worker_pool = None
 
     def config_notify(self):
         """
@@ -313,6 +379,11 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         Does nothing, as completions are processed in another thread.
         """
+        if completions:
+            self.log.info("wait: promises={0}".format(completions))
+
+            for p in completions:
+                p.finalize()
 
     def _require_hosts(self, hosts):
         """
@@ -471,13 +542,14 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         TODO:
           - InventoryNode probably needs to be able to report labels
         """
-        nodes = [orchestrator.InventoryNode(host_name, []) for host_name in self.inventory_cache]
+        return [orchestrator.InventoryNode(host_name) for host_name in self.inventory_cache]
 
+    @async_map_completion
     def _refresh_host_services(self, host):
         out, code = self._run_ceph_daemon(
             host, 'mon', 'ls', [], no_fsid=True)
         data = json.loads(''.join(out))
-        self.log.debug('refreshed host %s services: %s' % (host, data))
+        self.log.error('refreshed host %s services: %s' % (host, data))
         self.service_cache[host] = orchestrator.OutdatableData(data)
         return data
 
@@ -500,10 +572,10 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                     host, host_info.data))
                 in_cache.append(host_info.data)
 
-        def _get_services_result(self, results):
+        def _get_services_result(results):
             services = {}
-            for host, c in zip(hosts, results + in_cache):
-                services[host] = c.result[0]
+            for host, data in zip(hosts, results + in_cache):
+                services[host] = data
 
             result = []
             for host, ls in services.items():
@@ -540,7 +612,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                     result.append(sd)
             return result
 
-        return async_map_completion(self._refresh_host_services)(wait_for_args).then(
+        return self._refresh_host_services(wait_for_args).then(
             _get_services_result)
 
 
@@ -553,7 +625,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
                                     service_id=service_id,
                                     node_name=node_name,
                                     refresh=refresh)
-        return orchestrator.TrivialReadCompletion(result)
+        return result
 
     def service_action(self, action, service_type,
                        service_name=None,
@@ -561,8 +633,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         self.log.debug('service_action action %s type %s name %s id %s' % (
             action, service_type, service_name, service_id))
         if action == 'reload':
-            return orchestrator.TrivialReadCompletion(
-                ["Reload is a no-op"])
+            return trivial_result(["Reload is a no-op"])
         daemons = self._get_services(
             service_type,
             service_name=service_name,
@@ -572,13 +643,16 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             args.append((d.service_type, d.service_instance,
                                        d.nodename, action))
         if not args:
-            n = service_name
-            if n:
-                n += '-*'
-            raise orchestrator.OrchestratorError('Unable to find %s.%s daemon(s)' % (
-                service_type, n))
-        return async_map_completion(self._service_action)(args)
+            if service_name:
+                n = service_name + '-*'
+            else:
+                n = service_id
+            raise orchestrator.OrchestratorError(
+                'Unable to find %s.%s daemon(s)' % (
+                    service_type, n))
+        return self._service_action(args)
 
+    @async_map_completion
     def _service_action(self, service_type, service_id, host, action):
         if action == 'redeploy':
             # recreate the systemd unit and then restart
@@ -628,9 +702,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             # this implies the returned hosts are registered
             hosts = self._get_hosts()
 
-        def run(host_info):
-            # type: (orchestrator.OutdatableData) -> orchestrator.InventoryNode
-            host = host_info.data['name']
+        @async_map_completion
+        def _get_inventory(host, host_info):
+            # type: (str, orchestrator.OutdatableData) -> orchestrator.InventoryNode
 
             if host_info.outdated(self.inventory_cache_timeout) or refresh:
                 self.log.info("refresh stale inventory for '{}'".format(host))
@@ -647,17 +721,16 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             devices = inventory.Devices.from_json(host_info.data)
             return orchestrator.InventoryNode(host, devices)
 
-        return async_map_completion(run)(hosts.values())
+        return _get_inventory(hosts)
 
     def blink_device_light(self, ident_fault, on, locs):
-        # type: (str, bool, List[orchestrator.DeviceLightLoc]) -> SSHWriteCompletion
-        def blink(host, dev, ident_fault_, on_):
-            # type: (str, str, str, bool) -> str
+        @async_map_completion
+        def blink(host, dev):
             cmd = [
                 'lsmcli',
                 'local-disk-%s-led-%s' % (
-                    ident_fault_,
-                    'on' if on_ else 'off'),
+                    ident_fault,
+                    'on' if on else 'off'),
                 '--path', '/dev/' + dev,
             ]
             out, code = self._run_ceph_daemon(host, 'osd', 'shell', ['--'] + cmd,
@@ -665,11 +738,11 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             if code:
                 raise RuntimeError(
                     'Unable to affect %s light for %s:%s. Command: %s' % (
-                        ident_fault_, host, dev, ' '.join(cmd)))
+                        ident_fault, host, dev, ' '.join(cmd)))
             return "Set %s light for %s:%s %s" % (
-                ident_fault_, host, dev, 'on' if on_ else 'off')
+                ident_fault, host, dev, 'on' if on else 'off')
 
-        return async_map_completion(blink)(locs)
+        return blink(locs)
 
     @async_completion
     def _create_osd(self, all_hosts_, drive_group):
@@ -761,12 +834,14 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
           - support batch creation
         """
 
-        return self.get_hosts().then(self._create_osd)
+        return self.get_hosts().then(lambda hosts: self._create_osd(hosts, drive_group))
 
     def remove_osds(self, name):
         daemons = self._get_services('osd', service_id=name)
         args = [('osd.%s' % d.service_instance, d.nodename) for d in daemons]
-        return async_map_completion(self._remove_daemon)(args)
+        if not args:
+            raise OrchestratorError('Unable to find osd.%s' % name)
+        return self._remove_daemon(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host, keyring,
                        extra_args=[]):
@@ -811,6 +886,7 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             self.log.info("create_daemon({}): finished".format(host))
             conn.exit()
 
+    @async_map_completion
     def _remove_daemon(self, name, host):
         """
         Remove a daemon
@@ -823,22 +899,24 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         return "Removed {} from host '{}'".format(name, host)
 
     def _update_service(self, daemon_type, add_func, spec):
-        daemons = self._get_services(daemon_type, service_name=spec.name)
-        results = []
-        if len(daemons) > spec.count:
-            # remove some
-            to_remove = len(daemons) - spec.count
-            for d in daemons[0:to_remove]:
-                results.append(self._worker_pool.apply_async(
-                    self._remove_daemon,
-                    ('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename)))
-        elif len(daemons) < spec.count:
-            # add some
-            spec.count -= len(daemons)
-            return add_func(spec)
-        return SSHWriteCompletion(results)
+        def ___update_service(daemons):
+            if len(daemons) > spec.count:
+                # remove some
+                to_remove = len(daemons) - spec.count
+                args = []
+                for d in daemons[0:to_remove]:
+                    args.append(
+                        ('%s.%s' % (d.service_type, d.service_instance), d.nodename)
+                    )
+                return self._remove_daemon(args)
+            elif len(daemons) < spec.count:
+                # add some
+                spec.count -= len(daemons)
+                return add_func(spec)
+            return []
+        return self._get_services(daemon_type, service_name=spec.name).then(___update_service)
 
+    @async_map_completion
     def _create_mon(self, host, network, name):
         """
         Create a new monitor on the given host.
@@ -901,8 +979,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         # TODO: we may want to chain the creation of the monitors so they join
         # the quorum one at a time.
-        return async_map_completion(self._create_mon)(host_specs)
+        return self._create_mon(host_specs)
 
+    @async_map_completion
     def _create_mgr(self, host, name):
         """
         Create a new manager instance on a host.
@@ -924,7 +1003,9 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         Adjust the number of cluster managers.
         """
-        daemons = self._get_services('mgr')
+        return self._get_services('mgr').then(lambda daemons: self._update_mgrs(num, host_specs, daemons))
+
+    def _update_mgrs(self, num, host_specs, daemons):
         num_mgrs = len(daemons)
         if num == num_mgrs:
             return orchestrator.Completion(value="The requested number of managers exist.")
@@ -946,7 +1027,6 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             for standby in mgr_map.get('standbys', []):
                 connected.append(standby.get('name', ''))
             to_remove_damons = []
-            to_remove_mgr = []
             for d in daemons:
                 if d.service_instance not in connected:
                     to_remove_damons.append(('%s.%s' % (d.service_type, d.service_instance),
@@ -957,16 +1037,12 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             # otherwise, remove *any* mgr
             if num_to_remove > 0:
-                for daemon in daemons:
-                    to_remove_mgr.append((('%s.%s' % (d.service_type, d.service_instance), daemon.nodename))
+                for d in daemons:
+                    to_remove_damons.append(('%s.%s' % (d.service_type, d.service_instance), d.nodename))
                     num_to_remove -= 1
                     if num_to_remove == 0:
                         break
-            return async_map_completion(self._remove_daemon)(to_remove_damons).then(
-                lambda remove_daemon_result: async_map_completion(self._remove_daemon)(to_remove_mgr).then(
-                    lambda remove_mgr_result: remove_daemon_result + remove_mgr_result
-                )
-            )
+            return self._remove_daemon(to_remove_damons)
 
         else:
             # we assume explicit placement by which there are the same number of
@@ -988,26 +1064,19 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             self.log.info("creating {} managers on hosts: '{}'".format(
                 num_new_mgrs, ",".join([spec.hostname for spec in host_specs])))
 
-            for host_spec in host_specs:
-                name = host_spec.name or self.get_unique_name(daemons)
-                result = self._worker_pool.apply_async(self._create_mgr,
-                                                       (host_spec.hostname, name))
-                results.append(result)
-				
             args = []
             for host_spec in host_specs:
-			    name = host_spec.name or self.get_unique_name(daemons)
-				host = host_spec.hostname
+                name = host_spec.name or self.get_unique_name(daemons)
+                host = host_spec.hostname
                 args.append((host, name))
-        return async_map_completion(self._create_mgr)(args)
-			
-
-        return SSHWriteCompletion(results)
+        return self._create_mgr(args)
 
     def add_mds(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
             raise RuntimeError("must specify at least %d hosts" % spec.count)
-        daemons = self._get_services('mds')
+        return self._get_services('mds').then(lambda ds: self._add_mds(ds, spec))
+
+    def _add_mds(self, daemons, spec):
         args = []
         num_added = 0
         for host, _, name in spec.placement.nodes:
@@ -1023,11 +1092,12 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             sd.nodename = host
             daemons.append(sd)
             num_added += 1
-        return async_map_completion(self._create_mds)(args)
+        return self._create_mds(args)
 
     def update_mds(self, spec):
         return self._update_service('mds', self.add_mds, spec)
 
+    @async_map_completion
     def _create_mds(self, mds_id, host):
         # get mgr. key
         ret, keyring, err = self.mon_command({
@@ -1040,12 +1110,17 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self._create_daemon('mds', mds_id, host, keyring)
 
     def remove_mds(self, name):
-        daemons = self._get_services('mds')
-        if daemons:
-            args = [('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename) for d in daemons]
-            return async_map_completion(self._remove_daemon)(args)
-        raise orchestrator.OrchestratorError('Unable to find mds.%s[-*] daemon(s)' % name)
+        def _remove_mds(daemons):
+            args = []
+            for d in daemons:
+                if d.service_instance == name or d.service_instance.startswith(name + '.'):
+                    args.append(
+                        ('%s.%s' % (d.service_type, d.service_instance), d.nodename)
+                    )
+            if not args:
+                raise OrchestratorError('Unable to find mds.%s[-*] daemon(s)' % name)
+            return self._remove_daemon(args)
+        return self._get_services('mds').then(_remove_mds)
 
     def add_rgw(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
@@ -1057,24 +1132,28 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
             'name': 'rgw_zone',
             'value': spec.name,
         })
-        daemons = self._get_services('rgw')
-        args = []
-        num_added = 0
-        for host, _, name in spec.placement.nodes:
-            if num_added >= spec.count:
-                break
-            rgw_id = self.get_unique_name(daemons, spec.name, name)
-            self.log.debug('placing rgw.%s on host %s' % (rgw_id, host))
-            args.append((rgw_id, host))
-            # add to daemon list so next name(s) will also be unique
-            sd = orchestrator.ServiceDescription()
-            sd.service_instance = rgw_id
-            sd.service_type = 'rgw'
-            sd.nodename = host
-            daemons.append(sd)
-            num_added += 1
-        return async_map_completion(self._create_rgw)(args)
 
+        def _add_rgw(daemons):
+            args = []
+            num_added = 0
+            for host, _, name in spec.placement.nodes:
+                if num_added >= spec.count:
+                    break
+                rgw_id = self.get_unique_name(daemons, spec.name, name)
+                self.log.debug('placing rgw.%s on host %s' % (rgw_id, host))
+                args.append((rgw_id, host))
+                # add to daemon list so next name(s) will also be unique
+                sd = orchestrator.ServiceDescription()
+                sd.service_instance = rgw_id
+                sd.service_type = 'rgw'
+                sd.nodename = host
+                daemons.append(sd)
+                num_added += 1
+            return self._create_rgw(args)
+
+        return self._get_services('rgw').then(_add_rgw)
+
+    @async_map_completion
     def _create_rgw(self, rgw_id, host):
         ret, keyring, err = self.mon_command({
             'prefix': 'auth get-or-create',
@@ -1086,57 +1165,50 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self._create_daemon('rgw', rgw_id, host, keyring)
 
     def remove_rgw(self, name):
-        daemons = self._get_services('rgw')
 
-        args = []
-        for d in daemons:
-            if d.service_instance == name or d.service_instance.startswith(name + '.'):
-                args.append(('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename))
-        if args:
-            return async_map_completion(self._remove_daemon)(args)
-        raise RuntimeError('Unable to find rgw.%s[-*] daemon(s)' % name)
+        def _remove_rgw(daemons):
+            args = []
+            for d in daemons:
+                if d.service_instance == name or d.service_instance.startswith(name + '.'):
+                    args.append(('%s.%s' % (d.service_type, d.service_instance),
+                         d.nodename))
+            if args:
+                return self._remove_daemon(args)
+            raise RuntimeError('Unable to find rgw.%s[-*] daemon(s)' % name)
+
+        return self._get_services('rgw').then(_remove_rgw)
 
     def update_rgw(self, spec):
-        daemons = self._get_services('rgw', service_name=spec.name)
-        if len(daemons) > spec.count:
-            # remove some
-            to_remove = len(daemons) - spec.count
-            args = []
-            for d in daemons[0:to_remove]:
-                args.append((d.service_instance, d.nodename))
-            return async_map_completion(self._remove_rgw)(args)
-        elif len(daemons) < spec.count:
-            # add some
-            spec.count -= len(daemons)
-            return self.add_rgw(spec)
+        return self._update_service('rgw', self.add_rgw, spec)
 
     def add_rbd_mirror(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
             raise RuntimeError("must specify at least %d hosts" % spec.count)
         self.log.debug('nodes %s' % spec.placement.nodes)
-        daemons = self._get_services('rbd-mirror')
-        results = []
-        num_added = 0
-        for host, _, name in spec.placement.nodes:
-            if num_added >= spec.count:
-                break
-            daemon_id = self.get_unique_name(daemons, None, name)
-            self.log.debug('placing rbd-mirror.%s on host %s' % (daemon_id,
-                                                                 host))
-            results.append(
-                self._worker_pool.apply_async(self._create_rbd_mirror,
-                                              (daemon_id, host))
-            )
-            # add to daemon list so next name(s) will also be unique
-            sd = orchestrator.ServiceDescription()
-            sd.service_instance = daemon_id
-            sd.service_type = 'rbd-mirror'
-            sd.nodename = host
-            daemons.append(sd)
-            num_added += 1
-        return SSHWriteCompletion(results)
 
+        def _add_rbd_mirror(daemons):
+            args = []
+            num_added = 0
+            for host, _, name in spec.placement.nodes:
+                if num_added >= spec.count:
+                    break
+                daemon_id = self.get_unique_name(daemons, None, name)
+                self.log.debug('placing rbd-mirror.%s on host %s' % (daemon_id,
+                                                                     host))
+                args.append((daemon_id, host))
+
+                # add to daemon list so next name(s) will also be unique
+                sd = orchestrator.ServiceDescription()
+                sd.service_instance = daemon_id
+                sd.service_type = 'rbd-mirror'
+                sd.nodename = host
+                daemons.append(sd)
+                num_added += 1
+            return self._create_rbd_mirror(args)
+
+        return self._get_services('rbd-mirror').then(_add_rbd_mirror)
+
+    @async_map_completion
     def _create_rbd_mirror(self, daemon_id, host):
         ret, keyring, err = self.mon_command({
             'prefix': 'auth get-or-create',
@@ -1147,17 +1219,19 @@ class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self._create_daemon('rbd-mirror', daemon_id, host, keyring)
 
     def remove_rbd_mirror(self, name):
-        daemons = self._get_services('rbd-mirror')
-        results = []
-        for d in daemons:
-            if not name or d.service_instance == name:
-                results.append(self._worker_pool.apply_async(
-                    self._remove_daemon,
-                    ('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename)))
-        if not results and name:
-            raise RuntimeError('Unable to find rbd-mirror.%s daemon' % name)
-        return SSHWriteCompletion(results)
+        def _remove_rbd_mirror(daemons):
+            args = []
+            for d in daemons:
+                if not name or d.service_instance == name:
+                    args.append(
+                        ('%s.%s' % (d.service_type, d.service_instance),
+                         d.nodename)
+                    )
+            if not args and name:
+                raise RuntimeError('Unable to find rbd-mirror.%s daemon' % name)
+            return self._remove_daemon(args)
+
+        return self._get_services('rbd-mirror').then(_remove_rbd_mirror)
 
     def update_rbd_mirror(self, spec):
         return self._update_service('rbd-mirror', self.add_rbd_mirror, spec)

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -50,7 +50,7 @@ DEFAULT_SSH_CONFIG = ('Host *\n'
 class AsyncCompletion(orchestrator.Completion):
     def __init__(self, *args, **kwargs):
         self.__on_complete = None  # type: Callable
-        self.many = kwargs.pop('many')
+        self.many = kwargs.pop('many', False)
         super(AsyncCompletion, self).__init__(*args, **kwargs)
 
     def propagate_to_next(self):

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -56,14 +56,14 @@ class SSHCompletionmMixin(object):
 
 class SSHReadCompletion(SSHCompletionmMixin, orchestrator.ReadCompletion):
     @property
-    def is_complete(self):
+    def has_result(self):
         return all(map(lambda r: r.ready(), self._result))
 
 
 class SSHWriteCompletion(SSHCompletionmMixin, orchestrator.WriteCompletion):
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return all(map(lambda r: r.ready(), self._result))
 
     @property
@@ -90,7 +90,7 @@ class SSHWriteCompletionReady(SSHWriteCompletion):
         return self._result
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return True
 
     @property

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -4,6 +4,13 @@ import logging
 from functools import wraps
 
 import string
+try:
+    from typing import List, Dict, Optional, Callable, TypeVar, Type, Any
+except ImportError:
+    pass  # just for type checking
+
+T = TypeVar('T')
+
 import six
 import os
 import random
@@ -41,87 +48,86 @@ DEFAULT_SSH_CONFIG = ('Host *\n'
 #    multiple bootstrapping / initialization
 
 
-class SSHCompletionmMixin(object):
-    def __init__(self, result):
-        if isinstance(result, multiprocessing.pool.AsyncResult):
-            self._result = [result]
-        else:
-            self._result = result
-        assert isinstance(self._result, list)
+class AsyncCompletion(orchestrator.Completion[T]):
+    def __init__(self, *args, many=False, **kwargs):
+        self.__on_complete = None  # type: Callable[[T], Any]
+        self.many = many
+        super(AsyncCompletion, self).__init__(*args, **kwargs)
+
+    def propagate_to_next(self):
+        # We don't have a synchronous result.
+        pass
 
     @property
-    def result(self):
-        return list(map(lambda r: r.get(), self._result))
-
-
-class SSHReadCompletion(SSHCompletionmMixin, orchestrator.ReadCompletion):
-    @property
-    def has_result(self):
-        return all(map(lambda r: r.ready(), self._result))
-
-
-class SSHWriteCompletion(SSHCompletionmMixin, orchestrator.WriteCompletion):
+    def _progress_reference(self):
+        if hasattr(self.__on_complete, 'progress_id'):
+            return self.__on_complete
+        return None
 
     @property
-    def has_result(self):
-        return all(map(lambda r: r.ready(), self._result))
+    def _on_complete(self):
+        # type: () -> Optional[Callable[[T], Any]]
+        if self.__on_complete is None:
+            return None
 
-    @property
-    def is_effective(self):
-        return all(map(lambda r: r.ready(), self._result))
+        def callback(result):
+            if self._next_promise:
+                self._next_promise._value = result
+            else:
+                self._value = result
+            super(AsyncCompletion, self).propagate_to_next()
 
-    @property
-    def is_errored(self):
-        for r in self._result:
-            if not r.ready():
-                return False
-            if not r.successful():
-                return True
-        return False
+        def run(value):
+            if self.many:
+                SSHOrchestrator.instance._worker_pool.map_async(self.__on_complete, value,
+                                                                callback=callback)
+            else:
+                SSHOrchestrator.instance._worker_pool.apply_async(self.__on_complete, (value,),
+                                                                  callback=callback)
 
+        return run
 
-class SSHWriteCompletionReady(SSHWriteCompletion):
-    def __init__(self, result):
-        orchestrator.WriteCompletion.__init__(self)
-        self._result = result
-
-    @property
-    def result(self):
-        return self._result
-
-    @property
-    def has_result(self):
-        return True
-
-    @property
-    def is_effective(self):
-        return True
-
-    @property
-    def is_errored(self):
-        return False
+    @_on_complete.setter
+    def _on_complete(self, inner):
+        # type: (Callable[[T], Any]) -> None
+        self.__on_complete = inner
 
 
-def log_exceptions(f):
-    if six.PY3:
-        return f
-    else:
-        # Python 2 does no exception chaining, thus the
-        # real exception is lost
+def ssh_completion(cls=AsyncCompletion, **c_kwargs):
+    # type: (Type[orchestrator.Completion], Any) -> Callable
+    """
+    run the given function through `apply_async()` or `map_asyc()`
+    """
+    def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            try:
-                return f(*args, **kwargs)
-            except Exception:
-                logger.exception('something went wrong.')
-                raise
+            return cls(on_complete=lambda _: f(*args, **kwargs), **c_kwargs)
+
         return wrapper
+    return decorator
 
 
-class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
+def async_completion(f):
+    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    return ssh_completion()(f)
+
+
+def async_map_completion(f):
+    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    return ssh_completion(many=True)(f)
+
+
+def trivial_completion(f):
+    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
+    return ssh_completion(cls=orchestrator.Completion)(f)
+
+
+class SSHOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     _STORE_HOST_PREFIX = "host"
 
+
+    instance = None
     NATIVE_OPTIONS = []
     MODULE_OPTIONS = [
         {
@@ -174,6 +180,9 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         self._worker_pool = multiprocessing.pool.ThreadPool(1)
 
         self._reconfig_ssh()
+
+        SSHOrchestrator.instance = self
+        self.all_progress_references = list()  # type: List[orchestrator.ProgressReference]
 
         # the keys in inventory_cache are authoritative.
         #   You must not call remove_outdated()
@@ -430,36 +439,29 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
     def _get_hosts(self, wanted=None):
         return self.inventory_cache.items_filtered(wanted)
 
+    @async_completion
     def add_host(self, host):
         """
         Add a host to be managed by the orchestrator.
 
         :param host: host name
         """
-        @log_exceptions
-        def run(host):
-            self.inventory_cache[host] = orchestrator.OutdatableData()
-            self.service_cache[host] = orchestrator.OutdatableData()
-            return "Added host '{}'".format(host)
+        self.inventory_cache[host] = orchestrator.OutdatableData()
+        self.service_cache[host] = orchestrator.OutdatableData()
+        return "Added host '{}'".format(host)
 
-        return SSHWriteCompletion(
-            self._worker_pool.apply_async(run, (host,)))
-
+    @async_completion
     def remove_host(self, host):
         """
         Remove a host from orchestrator management.
 
         :param host: host name
         """
-        @log_exceptions
-        def run(host):
-            del self.inventory_cache[host]
-            del self.service_cache[host]
-            return "Removed host '{}'".format(host)
+        del self.inventory_cache[host]
+        del self.service_cache[host]
+        return "Removed host '{}'".format(host)
 
-        return SSHWriteCompletion(
-            self._worker_pool.apply_async(run, (host,)))
-
+    @trivial_completion
     def get_hosts(self):
         """
         Return a list of hosts managed by the orchestrator.
@@ -470,8 +472,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         TODO:
           - InventoryNode probably needs to be able to report labels
         """
-        nodes = [orchestrator.InventoryNode(host_name, inventory.Devices([])) for host_name in self.inventory_cache]
-        return orchestrator.TrivialReadCompletion(nodes)
+        nodes = [orchestrator.InventoryNode(host_name, []) for host_name in self.inventory_cache]
 
     def _refresh_host_services(self, host):
         out, code = self._run_ceph_daemon(
@@ -488,59 +489,61 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                       node_name=None,
                       refresh=False):
         hosts = []
-        wait_for = []
+        wait_for_args = []
+        in_cache = []
         for host, host_info in self.service_cache.items_filtered():
             hosts.append(host)
             if host_info.outdated(self.service_cache_timeout) or refresh:
                 self.log.info("refresing stale services for '{}'".format(host))
-                wait_for.append(
-                    SSHReadCompletion(self._worker_pool.apply_async(
-                        self._refresh_host_services, (host,))))
+                wait_for_args.append((host,))
             else:
                 self.log.debug('have recent services for %s: %s' % (
                     host, host_info.data))
-                wait_for.append(
-                    orchestrator.TrivialReadCompletion([host_info.data]))
-        self._orchestrator_wait(wait_for)
+                in_cache.append(host_info.data)
 
-        services = {}
-        for host, c in zip(hosts, wait_for):
-            services[host] = c.result[0]
+        def _get_services_result(self, results):
+            services = {}
+            for host, c in zip(hosts, results + in_cache):
+                services[host] = c.result[0]
 
-        result = []
-        for host, ls in services.items():
-            for d in ls:
-                if not d['style'].startswith('ceph-daemon'):
-                    self.log.debug('ignoring non-ceph-daemon on %s: %s' % (host, d))
-                    continue
-                if d['fsid'] != self._cluster_fsid:
-                    self.log.debug('ignoring foreign daemon on %s: %s' % (host, d))
-                    continue
-                self.log.debug('including %s' % d)
-                sd = orchestrator.ServiceDescription()
-                sd.service_type = d['name'].split('.')[0]
-                if service_type and service_type != sd.service_type:
-                    continue
-                if '.' in d['name']:
-                    sd.service_instance = '.'.join(d['name'].split('.')[1:])
-                else:
-                    sd.service_instance = host  # e.g., crash
-                if service_id and service_id != sd.service_instance:
-                    continue
-                if service_name and not sd.service_instance.startswith(service_name + '.'):
-                    continue
-                sd.nodename = host
-                sd.container_id = d['container_id']
-                sd.version = d['version']
-                sd.status_desc = d['state']
-                sd.status = {
-                    'running': 1,
-                    'stopped': 0,
-                    'error': -1,
-                    'unknown': -1,
-                }[d['state']]
-                result.append(sd)
-        return result
+            result = []
+            for host, ls in services.items():
+                for d in ls:
+                    if not d['style'].startswith('ceph-daemon'):
+                        self.log.debug('ignoring non-ceph-daemon on %s: %s' % (host, d))
+                        continue
+                    if d['fsid'] != self._cluster_fsid:
+                        self.log.debug('ignoring foreign daemon on %s: %s' % (host, d))
+                        continue
+                    self.log.debug('including %s' % d)
+                    sd = orchestrator.ServiceDescription()
+                    sd.service_type = d['name'].split('.')[0]
+                    if service_type and service_type != sd.service_type:
+                        continue
+                    if '.' in d['name']:
+                        sd.service_instance = '.'.join(d['name'].split('.')[1:])
+                    else:
+                        sd.service_instance = host  # e.g., crash
+                    if service_id and service_id != sd.service_instance:
+                        continue
+                    if service_name and not sd.service_instance.startswith(service_name + '.'):
+                        continue
+                    sd.nodename = host
+                    sd.container_id = d['container_id']
+                    sd.version = d['version']
+                    sd.status_desc = d['state']
+                    sd.status = {
+                        'running': 1,
+                        'stopped': 0,
+                        'error': -1,
+                        'unknown': -1,
+                    }[d['state']]
+                    result.append(sd)
+            return result
+
+        return async_map_completion(self._refresh_host_services)(wait_for_args).then(
+            _get_services_result)
+
 
     def describe_service(self, service_type=None, service_id=None,
                          node_name=None, refresh=False):
@@ -565,20 +568,17 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             service_type,
             service_name=service_name,
             service_id=service_id)
-        results = []
+        args = []
         for d in daemons:
-            results.append(self._worker_pool.apply_async(
-                self._service_action, (d.service_type, d.service_instance,
-                                       d.nodename, action)))
-        if not results:
-            if service_name:
-                n = service_name + '-*'
-            else:
-                n = service_id
-            raise OrchestratorError(
-                'Unable to find %s.%s daemon(s)' % (
-                    service_type, n))
-        return SSHWriteCompletion(results)
+            args.append((d.service_type, d.service_instance,
+                                       d.nodename, action))
+        if not args:
+            n = service_name
+            if n:
+                n += '-*'
+            raise orchestrator.OrchestratorError('Unable to find %s.%s daemon(s)' % (
+                service_type, n))
+        return async_map_completion(self._service_action)(args)
 
     def _service_action(self, service_type, service_id, host, action):
         if action == 'redeploy':
@@ -629,9 +629,9 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             # this implies the returned hosts are registered
             hosts = self._get_hosts()
 
-        @log_exceptions
-        def run(host, host_info):
-            # type: (str, orchestrator.OutdatableData) -> orchestrator.InventoryNode
+        def run(host_info):
+            # type: (orchestrator.OutdatableData) -> orchestrator.InventoryNode
+            host = host_info.data['name']
 
             if host_info.outdated(self.inventory_cache_timeout) or refresh:
                 self.log.info("refresh stale inventory for '{}'".format(host))
@@ -648,17 +648,10 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             devices = inventory.Devices.from_json(host_info.data)
             return orchestrator.InventoryNode(host, devices)
 
-        results = []
-        for key, host_info in hosts:
-            result = self._worker_pool.apply_async(run, (key, host_info))
-            results.append(result)
+        return async_map_completion(run)(hosts.values())
 
-        return SSHReadCompletion(results)
-
-    @log_exceptions
     def blink_device_light(self, ident_fault, on, locs):
         # type: (str, bool, List[orchestrator.DeviceLightLoc]) -> SSHWriteCompletion
-
         def blink(host, dev, ident_fault_, on_):
             # type: (str, str, str, bool) -> str
             cmd = [
@@ -677,16 +670,20 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             return "Set %s light for %s:%s %s" % (
                 ident_fault_, host, dev, 'on' if on_ else 'off')
 
-        results = []
-        for loc in locs:
-            results.append(
-                self._worker_pool.apply_async(
-                    blink,
-                    (loc.host, loc.dev, ident_fault, on)))
-        return SSHWriteCompletion(results)
+        return async_map_completion(blink)(locs)
 
-    @log_exceptions
-    def _create_osd(self, host, drive_group):
+    @async_completion
+    def _create_osd(self, all_hosts_, drive_group):
+        all_hosts = orchestrator.InventoryNode.get_host_names(all_hosts_)
+        assert len(drive_group.hosts(all_hosts)) == 1
+        assert len(drive_group.data_devices.paths) > 0
+        assert all(map(lambda p: isinstance(p, six.string_types),
+            drive_group.data_devices.paths))
+
+        host = drive_group.hosts(all_hosts)[0]
+        self._require_hosts(host)
+
+
         # get bootstrap key
         ret, keyring, err = self.mon_command({
             'prefix': 'auth get',
@@ -751,7 +748,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
         return "Created osd(s) on host '{}'".format(host)
 
-    def create_osds(self, drive_group, all_hosts=None):
+    def create_osds(self, drive_group):
         """
         Create a new osd.
 
@@ -764,29 +761,13 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
           - support full drive_group specification
           - support batch creation
         """
-        assert len(drive_group.hosts(all_hosts)) == 1
-        assert len(drive_group.data_devices.paths) > 0
-        assert all(map(lambda p: isinstance(p, six.string_types),
-            drive_group.data_devices.paths))
 
-        host = drive_group.hosts(all_hosts)[0]
-        self._require_hosts(host)
-
-        result = self._worker_pool.apply_async(self._create_osd, (host,
-                drive_group))
-
-        return SSHWriteCompletion(result)
+        return self.get_hosts().then(self._create_osd)
 
     def remove_osds(self, name):
         daemons = self._get_services('osd', service_id=name)
-        results = []
-        for d in daemons:
-            results.append(self._worker_pool.apply_async(
-                self._remove_daemon,
-                ('osd.%s' % d.service_instance, d.nodename)))
-        if not results:
-            raise OrchestratorError('Unable to find osd.%s' % name)
-        return SSHWriteCompletion(results)
+        args = [('osd.%s' % d.service_instance, d.nodename) for d in daemons]
+        return async_map_completion(self._remove_daemon)(args)
 
     def _create_daemon(self, daemon_type, daemon_id, host, keyring,
                        extra_args=[]):
@@ -892,7 +873,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         mon_map = self.get("mon_map")
         num_mons = len(mon_map["mons"])
         if num == num_mons:
-            return SSHWriteCompletionReady("The requested number of monitors exist.")
+            return orchestrator.Completion(value="The requested number of monitors exist.")
         if num < num_mons:
             raise NotImplementedError("Removing monitors is not supported.")
 
@@ -921,14 +902,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
         # TODO: we may want to chain the creation of the monitors so they join
         # the quorum one at a time.
-        results = []
-        for host, network, name in host_specs:
-            result = self._worker_pool.apply_async(self._create_mon,
-                                                   (host, network, name))
-
-            results.append(result)
-
-        return SSHWriteCompletion(results)
+        return async_map_completion(self._create_mon)(host_specs)
 
     def _create_mgr(self, host, name):
         """
@@ -954,7 +928,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         daemons = self._get_services('mgr')
         num_mgrs = len(daemons)
         if num == num_mgrs:
-            return SSHWriteCompletionReady("The requested number of managers exist.")
+            return orchestrator.Completion(value="The requested number of managers exist.")
 
         self.log.debug("Trying to update managers on: {}".format(host_specs))
         # check that all the hosts are registered
@@ -972,13 +946,12 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 connected.append(mgr_map.get('active_name', ''))
             for standby in mgr_map.get('standbys', []):
                 connected.append(standby.get('name', ''))
+            to_remove_damons = []
+            to_remove_mgr = []
             for d in daemons:
                 if d.service_instance not in connected:
-                    result = self._worker_pool.apply_async(
-                        self._remove_daemon,
-                        ('%s.%s' % (d.service_type, d.service_instance),
+                    to_remove_damons.append(('%s.%s' % (d.service_type, d.service_instance),
                          d.nodename))
-                    results.append(result)
                     num_to_remove -= 1
                     if num_to_remove == 0:
                         break
@@ -986,14 +959,15 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             # otherwise, remove *any* mgr
             if num_to_remove > 0:
                 for daemon in daemons:
-                    result = self._worker_pool.apply_async(
-                        self._remove_daemon,
-                        ('%s.%s' % (d.service_type, d.service_instance),
-                         d.nodename))
-                    results.append(result)
+                    to_remove_mgr.append((('%s.%s' % (d.service_type, d.service_instance), daemon.nodename))
                     num_to_remove -= 1
                     if num_to_remove == 0:
                         break
+            return async_map_completion(self._remove_daemon)(to_remove_damons).then(
+                lambda remove_daemon_result: async_map_completion(self._remove_daemon)(to_remove_mgr).then(
+                    lambda remove_mgr_result: remove_daemon_result + remove_mgr_result
+                )
+            )
 
         else:
             # we assume explicit placement by which there are the same number of
@@ -1020,6 +994,14 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
                 result = self._worker_pool.apply_async(self._create_mgr,
                                                        (host_spec.hostname, name))
                 results.append(result)
+				
+            args = []
+            for host_spec in host_specs:
+			    name = host_spec.name or self.get_unique_name(daemons)
+				host = host_spec.hostname
+                args.append((host, name))
+        return async_map_completion(self._create_mgr)(args)
+			
 
         return SSHWriteCompletion(results)
 
@@ -1027,16 +1009,14 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
             raise RuntimeError("must specify at least %d hosts" % spec.count)
         daemons = self._get_services('mds')
-        results = []
+        args = []
         num_added = 0
         for host, _, name in spec.placement.nodes:
             if num_added >= spec.count:
                 break
             mds_id = self.get_unique_name(daemons, spec.name, name)
             self.log.debug('placing mds.%s on host %s' % (mds_id, host))
-            results.append(
-                self._worker_pool.apply_async(self._create_mds, (mds_id, host))
-            )
+            args.append((mds_id, host))
             # add to daemon list so next name(s) will also be unique
             sd = orchestrator.ServiceDescription()
             sd.service_instance = mds_id
@@ -1044,7 +1024,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             sd.nodename = host
             daemons.append(sd)
             num_added += 1
-        return SSHWriteCompletion(results)
+        return async_map_completion(self._create_mds)(args)
 
     def update_mds(self, spec):
         return self._update_service('mds', self.add_mds, spec)
@@ -1062,16 +1042,11 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     def remove_mds(self, name):
         daemons = self._get_services('mds')
-        results = []
-        for d in daemons:
-            if d.service_instance == name or d.service_instance.startswith(name + '.'):
-                results.append(self._worker_pool.apply_async(
-                    self._remove_daemon,
-                    ('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename)))
-        if not results:
-            raise OrchestratorError('Unable to find mds.%s[-*] daemon(s)' % name)
-        return SSHWriteCompletion(results)
+        if daemons:
+            args = [('%s.%s' % (d.service_type, d.service_instance),
+                     d.nodename) for d in daemons]
+            return async_map_completion(self._remove_daemon)(args)
+        raise orchestrator.OrchestratorError('Unable to find mds.%s[-*] daemon(s)' % name)
 
     def add_rgw(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:
@@ -1084,16 +1059,14 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             'value': spec.name,
         })
         daemons = self._get_services('rgw')
-        results = []
+        args = []
         num_added = 0
         for host, _, name in spec.placement.nodes:
             if num_added >= spec.count:
                 break
             rgw_id = self.get_unique_name(daemons, spec.name, name)
             self.log.debug('placing rgw.%s on host %s' % (rgw_id, host))
-            results.append(
-                self._worker_pool.apply_async(self._create_rgw, (rgw_id, host))
-            )
+            args.append((rgw_id, host))
             # add to daemon list so next name(s) will also be unique
             sd = orchestrator.ServiceDescription()
             sd.service_instance = rgw_id
@@ -1101,7 +1074,7 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
             sd.nodename = host
             daemons.append(sd)
             num_added += 1
-        return SSHWriteCompletion(results)
+        return async_map_completion(self._create_rgw)(args)
 
     def _create_rgw(self, rgw_id, host):
         ret, keyring, err = self.mon_command({
@@ -1115,19 +1088,29 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
 
     def remove_rgw(self, name):
         daemons = self._get_services('rgw')
-        results = []
+
+        args = []
         for d in daemons:
             if d.service_instance == name or d.service_instance.startswith(name + '.'):
-                results.append(self._worker_pool.apply_async(
-                    self._remove_daemon,
-                    ('%s.%s' % (d.service_type, d.service_instance),
-                     d.nodename)))
-        if not results:
-            raise RuntimeError('Unable to find rgw.%s[-*] daemon(s)' % name)
-        return SSHWriteCompletion(results)
+                args.append(('%s.%s' % (d.service_type, d.service_instance),
+                     d.nodename))
+        if args:
+            return async_map_completion(self._remove_daemon)(args)
+        raise RuntimeError('Unable to find rgw.%s[-*] daemon(s)' % name)
 
     def update_rgw(self, spec):
-        return self._update_service('rgw', self.add_rgw, spec)
+        daemons = self._get_services('rgw', service_name=spec.name)
+        if len(daemons) > spec.count:
+            # remove some
+            to_remove = len(daemons) - spec.count
+            args = []
+            for d in daemons[0:to_remove]:
+                args.append((d.service_instance, d.nodename))
+            return async_map_completion(self._remove_rgw)(args)
+        elif len(daemons) < spec.count:
+            # add some
+            spec.count -= len(daemons)
+            return self.add_rgw(spec)
 
     def add_rbd_mirror(self, spec):
         if not spec.placement.nodes or len(spec.placement.nodes) < spec.count:

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -301,21 +301,10 @@ class SSHOrchestrator(MgrModule, orchestrator.OrchestratorClientMixin):
         """
         return self.can_run()
 
-    def wait(self, completions):
-        self.log.info("wait: completions={}".format(completions))
-
-        complete = True
-        for c in completions:
-            if c.is_complete:
-                continue
-
-            if not isinstance(c, SSHReadCompletion) and \
-                    not isinstance(c, SSHWriteCompletion):
-                raise TypeError("unexpected completion: {}".format(c.__class__))
-
-            complete = False
-
-        return complete
+    def process(self, completions):
+        """
+        Does nothing, as completions are processed in another thread.
+        """
 
     def _require_hosts(self, hosts):
         """

--- a/src/pybind/mgr/ssh/module.py
+++ b/src/pybind/mgr/ssh/module.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     pass  # just for type checking
 
-T = TypeVar('T')
 
 import six
 import os
@@ -48,10 +47,10 @@ DEFAULT_SSH_CONFIG = ('Host *\n'
 #    multiple bootstrapping / initialization
 
 
-class AsyncCompletion(orchestrator.Completion[T]):
-    def __init__(self, *args, many=False, **kwargs):
-        self.__on_complete = None  # type: Callable[[T], Any]
-        self.many = many
+class AsyncCompletion(orchestrator.Completion):
+    def __init__(self, *args, **kwargs):
+        self.__on_complete = None  # type: Callable
+        self.many = kwargs.pop('many')
         super(AsyncCompletion, self).__init__(*args, **kwargs)
 
     def propagate_to_next(self):
@@ -66,7 +65,7 @@ class AsyncCompletion(orchestrator.Completion[T]):
 
     @property
     def _on_complete(self):
-        # type: () -> Optional[Callable[[T], Any]]
+        # type: () -> Optional[Callable]
         if self.__on_complete is None:
             return None
 
@@ -89,7 +88,7 @@ class AsyncCompletion(orchestrator.Completion[T]):
 
     @_on_complete.setter
     def _on_complete(self, inner):
-        # type: (Callable[[T], Any]) -> None
+        # type: (Callable) -> None
         self.__on_complete = inner
 
 
@@ -108,17 +107,17 @@ def ssh_completion(cls=AsyncCompletion, **c_kwargs):
 
 
 def async_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    # type: (Callable) -> Callable[..., AsyncCompletion]
     return ssh_completion()(f)
 
 
 def async_map_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., AsyncCompletion[T]]
+    # type: (Callable) -> Callable[..., AsyncCompletion]
     return ssh_completion(many=True)(f)
 
 
 def trivial_completion(f):
-    # type: (Callable[..., T]) -> Callable[..., orchestrator.Completion[T]]
+    # type: (Callable) -> Callable[..., orchestrator.Completion]
     return ssh_completion(cls=orchestrator.Completion)(f)
 
 

--- a/src/pybind/mgr/ssh/tests/fixtures.py
+++ b/src/pybind/mgr/ssh/tests/fixtures.py
@@ -1,0 +1,40 @@
+from contextlib import contextmanager
+
+import pytest
+
+from ssh import SSHOrchestrator
+from tests import mock
+
+
+def set_store(self, k, v):
+    if v is None:
+        del self._store[k]
+    else:
+        self._store[k] = v
+
+
+def get_store(self, k):
+    return self._store[k]
+
+
+def get_store_prefix(self, prefix):
+    return {
+        k: v for k, v in self._store.items()
+        if k.startswith(prefix)
+    }
+
+
+@pytest.yield_fixture()
+def ssh_module():
+    with mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _, key: __file__),\
+            mock.patch("ssh.module.SSHOrchestrator.set_store", set_store),\
+            mock.patch("ssh.module.SSHOrchestrator.get_store", get_store),\
+            mock.patch("ssh.module.SSHOrchestrator.get_store_prefix", get_store_prefix):
+        m = SSHOrchestrator.__new__ (SSHOrchestrator)
+        m._store = {
+            'ssh_config': '',
+            'ssh_identity_key': '',
+            'ssh_identity_pub': '',
+        }
+        m.__init__('ssh', 0, 0)
+        yield m

--- a/src/pybind/mgr/ssh/tests/test_completion.py
+++ b/src/pybind/mgr/ssh/tests/test_completion.py
@@ -1,0 +1,171 @@
+import sys
+import time
+
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+import pytest
+
+
+from orchestrator import raise_if_exception, Completion
+from .fixtures import ssh_module
+from ..module import trivial_completion, async_completion, async_map_completion, SSHOrchestrator
+
+
+class TestCompletion(object):
+    def _wait(self, m, c):
+        # type: (SSHOrchestrator, Completion) -> Any
+        m.process([c])
+        m.process([c])
+
+        for _ in range(30):
+            if c.is_finished:
+                raise_if_exception(c)
+                return c.result
+            time.sleep(0.1)
+        assert False, "timeout" + str(c._state)
+
+    def test_trivial(self, ssh_module):
+        @trivial_completion
+        def run(x):
+            return x+1
+        assert self._wait(ssh_module, run(1)) == 2
+
+    @pytest.mark.parametrize("input", [
+        ((1, ), ),
+        ((1, 2), ),
+        (("hallo", ), ),
+        (("hallo", "foo"), ),
+    ])
+    def test_async(self, input, ssh_module):
+        @async_completion
+        def run(*args):
+            return str(args)
+
+        assert self._wait(ssh_module, run(*input)) == str(input)
+
+    @pytest.mark.parametrize("input,expected", [
+        ([], []),
+        ([1], ["(1,)"]),
+        (["hallo"], ["('hallo',)"]),
+        ("hi", ["('h',)", "('i',)"]),
+        (list(range(5)), [str((x, )) for x in range(5)]),
+        ([(1, 2), (3, 4)], ["(1, 2)", "(3, 4)"]),
+    ])
+    def test_async_map(self, input, expected, ssh_module):
+        @async_map_completion
+        def run(*args):
+            return str(args)
+
+        c = run(input)
+        self._wait(ssh_module, c)
+        assert c.result == expected
+
+    def test_async_self(self, ssh_module):
+        class Run(object):
+            def __init__(self):
+                self.attr = 1
+
+            @async_completion
+            def run(self, x):
+                assert self.attr == 1
+                return x + 1
+
+        assert self._wait(ssh_module, Run().run(1)) == 2
+
+    @pytest.mark.parametrize("input,expected", [
+        ([], []),
+        ([1], ["(1,)"]),
+        (["hallo"], ["('hallo',)"]),
+        ("hi", ["('h',)", "('i',)"]),
+        (list(range(5)), [str((x, )) for x in range(5)]),
+        ([(1, 2), (3, 4)], ["(1, 2)", "(3, 4)"]),
+    ])
+    def test_async_map_self(self, input, expected, ssh_module):
+        class Run(object):
+            def __init__(self):
+                self.attr = 1
+
+            @async_map_completion
+            def run(self, *args):
+                assert self.attr == 1
+                return str(args)
+
+        c = Run().run(input)
+        self._wait(ssh_module, c)
+        assert c.result == expected
+
+    def test_then1(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            return x+1
+
+        assert self._wait(ssh_module, run([1,2]).then(str)) == '[2, 3]'
+
+    def test_then2(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        @async_completion
+        def async_str(results):
+            return str(results)
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]'
+
+    def test_then3(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        def async_str(results):
+            return async_completion(str)(results)
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]'
+
+    def test_then4(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return x+1
+
+        def async_str(results):
+            return async_completion(str)(results).then(lambda x: x + "hello")
+
+        c = run([1,2]).then(async_str)
+
+        self._wait(ssh_module, c)
+        assert c.result == '[2, 3]hello'
+
+    @pytest.mark.skip(reason="see limitation of async_map_completion")
+    def test_then5(self, ssh_module):
+        @async_map_completion
+        def run(x):
+            time.sleep(0.1)
+            return async_completion(str)(x+1)
+
+        c = run([1,2])
+
+        self._wait(ssh_module, c)
+        assert c.result == "['2', '3']"
+
+    @pytest.mark.skipif(sys.version_info < (3,0), reason="requires python3")
+    def test_raise(self, ssh_module):
+        @async_completion
+        def run(x):
+            raise ZeroDivisionError()
+
+        with pytest.raises(ZeroDivisionError):
+            self._wait(ssh_module, run(1))
+

--- a/src/pybind/mgr/ssh/tests/test_ssh.py
+++ b/src/pybind/mgr/ssh/tests/test_ssh.py
@@ -1,15 +1,176 @@
-from orchestrator import ServiceDescription
+import json
+import time
+from contextlib import contextmanager
+
+from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
+
+try:
+    from typing import Any
+except ImportError:
+    pass
+
+from orchestrator import ServiceDescription, raise_if_exception, Completion, InventoryNode, \
+    StatelessServiceSpec, PlacementSpec, RGWSpec, parse_host_specs
 from ..module import SSHOrchestrator
 from tests import mock
+from .fixtures import ssh_module
 
 
-@mock.patch("ssh.module.SSHOrchestrator.get_ceph_option", lambda _,key: __file__)
-def test_get_unique_name():
-    o = SSHOrchestrator('module_name', 0, 0)
-    existing = [
-        ServiceDescription(service_instance='mon.a')
-    ]
-    new_mon = o.get_unique_name(existing, 'mon')
-    assert new_mon.startswith('mon.')
-    assert new_mon != 'mon.a'
+"""
+TODOs:
+    There is really room for improvement here. I just quickly assembled theses tests.
+    I general, everything should be testes in Teuthology as well. Reasons for
+    also testing this here is the development roundtrip time.
+"""
+
+
+
+def _run_ceph_daemon(ret):
+    def foo(*args, **kwargs):
+        return ret, 0
+    return foo
+
+def mon_command(*args, **kwargs):
+    return 0, '', ''
+
+
+class TestSSH(object):
+    def _wait(self, m, c):
+        # type: (SSHOrchestrator, Completion) -> Any
+        m.process([c])
+        m.process([c])
+
+        for _ in range(30):
+            if c.is_finished:
+                raise_if_exception(c)
+                return c.result
+            time.sleep(0.1)
+        assert False, "timeout" + str(c._state)
+
+    @contextmanager
+    def _with_host(self, m, name):
+        self._wait(m, m.add_host(name))
+        yield
+        self._wait(m, m.remove_host(name))
+
+    def test_get_unique_name(self, ssh_module):
+        existing = [
+            ServiceDescription(service_instance='mon.a')
+        ]
+        new_mon = ssh_module.get_unique_name(existing, 'mon')
+        assert new_mon.startswith('mon.')
+        assert new_mon != 'mon.a'
+
+    def test_host(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            assert self._wait(ssh_module, ssh_module.get_hosts()) == [InventoryNode('test')]
+        c = ssh_module.get_hosts()
+        assert self._wait(ssh_module, c) == []
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    def test_service_ls(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.describe_service()
+            assert self._wait(ssh_module, c) == []
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    def test_device_ls(self, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.get_inventory()
+            assert self._wait(ssh_module, c) == [InventoryNode('test')]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mon_update(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.update_mons(1, [parse_host_specs('test:0.0.0.0')])
+            assert self._wait(ssh_module, c) == ["(Re)deployed mon.test on host 'test'"]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('[]'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mgr_update(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.update_mgrs(1, [parse_host_specs('test:0.0.0.0')])
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed mgr." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_create_osds(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            dg = DriveGroupSpec('test', DeviceSelection(paths=['']))
+            c = ssh_module.create_osds(dg)
+            assert self._wait(ssh_module, c) == "Created osd(s) on host 'test'"
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_mds(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_mds(StatelessServiceSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed mds.name." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_rgw(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_rgw(RGWSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed rgw.name." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon(
+        json.dumps([
+            dict(
+                name='rgw.myrgw.foobar',
+                style='ceph-daemon',
+                fsid='fsid',
+                container_id='container_id',
+                version='version',
+                state='running',
+            )
+        ])
+    ))
+    def test_remove_rgw(self, ssh_module):
+        ssh_module._cluster_fsid = "fsid"
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.remove_rgw('myrgw')
+            out = self._wait(ssh_module, c)
+            assert out == ["Removed rgw.myrgw.foobar from host 'test'"]
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_rbd_mirror(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            ps = PlacementSpec(nodes=['test'])
+            c = ssh_module.add_rbd_mirror(StatelessServiceSpec('name', ps))
+            [out] = self._wait(ssh_module, c)
+            assert "(Re)deployed rbd-mirror." in out
+            assert " on host 'test'" in out
+
+    @mock.patch("ssh.module.SSHOrchestrator._run_ceph_daemon", _run_ceph_daemon('{}'))
+    @mock.patch("ssh.module.SSHOrchestrator.send_command")
+    @mock.patch("ssh.module.SSHOrchestrator.mon_command", mon_command)
+    @mock.patch("ssh.module.SSHOrchestrator._get_connection")
+    def test_blink_device_light(self, _send_command, _get_connection, ssh_module):
+        with self._with_host(ssh_module, 'test'):
+            c = ssh_module.blink_device_light('ident', True, [('test', '')])
+            assert self._wait(ssh_module, c) == ['Set ident light for test: on']
+
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -67,7 +67,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def process(self, completions):
         # type: (List[TestCompletion]) -> None
         if completions:
-            self.log.info("wait: promises={0}".format(completions))
+            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
 
             for p in completions:
                 p.evaluate()

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -19,7 +19,7 @@ import orchestrator
 
 
 class TestCompletionMixin(object):
-    all_completions = []  # Hacky global
+    all_completions = []  # type: orchestrator.Completion
 
     def __init__(self, cb, message, *args, **kwargs):
         super(TestCompletionMixin, self).__init__(*args, **kwargs)
@@ -37,7 +37,7 @@ class TestCompletionMixin(object):
         return self._result
 
     @property
-    def is_complete(self):
+    def has_result(self):
         return self._complete
 
     def execute(self):
@@ -64,7 +64,7 @@ class TestWriteCompletion(TestCompletionMixin, orchestrator.WriteCompletion):
         super(TestWriteCompletion, self).__init__(cb, message)
 
     @property
-    def is_persistent(self):
+    def has_result(self):
         return (not self.is_errored) and self.executed
 
     @property
@@ -114,7 +114,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
                         c.__class__
                     ))
 
-            if not c.has_result:
+            if c.needs_result:
                 c.execute()
 
     @CLICommand('test_orchestrator load_data', '', 'load dummy data into test orchestrator', 'w')
@@ -153,7 +153,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             self.wait(TestCompletionMixin.all_completions)
             TestCompletionMixin.all_completions = [c for c in TestCompletionMixin.all_completions if
-                                                   not c.is_complete]
+                                                   c.is_finished]
 
             self._shutdown.wait(5)
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -15,16 +15,14 @@ from mgr_module import MgrModule
 
 import orchestrator
 
-T = TypeVar('T')
 
-
-class TestCompletion(orchestrator.Completion[T]):
+class TestCompletion(orchestrator.Completion):
     def evaluate(self):
         self._first_promise.finalize(None)
 
 
 def deferred_read(f):
-    # type: (Callable[..., T]) -> Callable[..., TestCompletion[T]]
+    # type: (Callable) -> Callable[..., TestCompletion]
     """
     Decorator to make methods return
     a completion object that executes themselves.
@@ -39,7 +37,7 @@ def deferred_read(f):
 
 def deferred_write(message):
     def inner(f):
-        # type: (Callable[..., T]) -> Callable[..., TestCompletion[T]]
+        # type: (Callable) -> Callable[..., TestCompletion]
 
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -21,7 +21,7 @@ import orchestrator
 
 class TestCompletion(orchestrator.Completion):
     def evaluate(self):
-        self._first_promise.finalize(None)
+        self.finalize(None)
 
 
 def deferred_read(f):

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -5,7 +5,10 @@ import os
 import threading
 import functools
 from subprocess import check_output, CalledProcessError
-from typing import Callable, TypeVar, List
+try:
+    from typing import Callable, List
+except ImportError:
+    pass  # type checking
 
 import six
 

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -22,7 +22,6 @@ if 'UNITTEST' in os.environ:
             self._ceph_get = mock.MagicMock()
             self._ceph_get_module_option = mock.MagicMock()
             self._ceph_log = mock.MagicMock()
-            self._ceph_get_option = mock.MagicMock()
             self._ceph_get_store = lambda _: ''
             self._ceph_get_store_prefix = lambda _: {}
 

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 import json
-from unittest.mock import MagicMock
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    # py2
+    from mock import MagicMock
 
 import pytest
 

--- a/src/pybind/mgr/tests/test_orchestrator.py
+++ b/src/pybind/mgr/tests/test_orchestrator.py
@@ -177,13 +177,13 @@ def test_progress():
                                       completion=lambda: Completion(
                                           on_complete=lambda _: progress_val))
     )
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.0, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.0, [('origin', 'orchestrator')])
 
     c.finalize()
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.5, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.5, [('origin', 'orchestrator')])
 
     c.progress_reference.update()
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', progress_val, ['orchestrator'])
+    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', progress_val, [('origin', 'orchestrator')])
     assert not c.progress_reference.effective
 
     progress_val = 1

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -5,4 +5,4 @@ skipsdist = true
 [testenv]
 setenv = UNITTEST = true
 deps = -rrequirements.txt
-commands = pytest --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}
+commands = pytest -v --cov --cov-append --cov-report=term --doctest-modules {posargs:mgr_util.py tests/ ssh/}


### PR DESCRIPTION
This is needed to correctly set the state of the completion, so that
Completion.has_result returns true.  Without this, _orchestrator_wait()
will spin forever if given a TrivialReadCompletion.

Signed-off-by: Tim Serong <tserong@suse.com>